### PR TITLE
docs: tax-collect スキル設計プランの追加

### DIFF
--- a/plan/20260411_1302_tax-collect.md
+++ b/plan/20260411_1302_tax-collect.md
@@ -1,0 +1,289 @@
+# tax-collect スキル設計プラン
+
+## 目的
+
+1. **確定申告に何が必要かを定義する**（このPJの役割）
+2. **各サービスからの収集を自動化する**（人間がやってきた手作業のSkill化）
+
+---
+
+## 確定申告に必要な書類・情報の定義
+
+### 株式（証券会社）— 今フェーズの対象
+
+| 書類 | 用途 | 備考 |
+|---|---|---|
+| 特定口座年間取引報告書 | 株式譲渡損益・配当の申告 | 特定口座（源泉徴収あり/なし）保有者 |
+| 配当金の支払調書 | 配当所得の申告 | NISA・一般口座分 |
+| 年間取引報告書（一般口座） | 譲渡損益の計算 | 一般口座保有者のみ |
+
+> ※取引（売却）がない場合は報告書が発行されない（さわかみ投信・ひふみ投信の例）
+
+### FX（今後）
+
+| 書類 | 用途 |
+|---|---|
+| 年間損益報告書 | 先物取引に係る雑所得の申告 |
+
+### クラウドファンディング（今後）
+
+| 書類 | 用途 |
+|---|---|
+| 分配金・配当の支払調書 | 雑所得・配当所得の申告 |
+
+---
+
+## 対象証券会社一覧（2025年度実績ベース）
+
+| 会社名 | コード | マイナ連携 | XML | 画面ナビゲーション |
+|---|---|---|---|---|
+| SBI証券 | sbi | 〇 | 〇 | 口座管理→電子交付書面 |
+| 楽天証券 | rakuten | × | 〇 | マイメニュー→損益・税金履歴→確定申告サポート→取引報告書等 |
+| 野村證券 | nomura | 〇 | 〇 | 口座情報/手続き→取引報告書Web交付 |
+| マネックス証券 | monex | 〇 | 〇 | 保有残高・口座管理→電子交付書面 |
+| 松井証券 | matsui | × | 〇 | 口座管理→電子帳票→電子書面閲覧 |
+| GMOクリック証券 | gmo-click | × | 〇 | マイページ→精算表→電子書類閲覧 |
+| SMBC日興証券 | smbc-nikko | × | 〇 | 各種お手続き→電子交付サービス→電子交付履歴 |
+| 三菱UFJ eスマート証券 | mufg-esmart | 〇 | × | 資産管理→電子交付→報告書等 |
+| tsumiki証券 | tsumiki | × | × | メニュー→資産の状況→お取引に関する報告書 |
+| セゾンポケット | saison-pocket | × | × | メニュー→お客様サポートWeb→電子交付サービス |
+| 大和CONNECT証券 | daiwa-connect | × | × | メニュー→お客様情報→電子交付サービス |
+| PayPay証券 | paypay | × | × | メニュー→電子交付書類 |
+| ウィブル証券 | webull | × | × | 資産（アイコン）→帳票 |
+| 野村證券持株会 | nomura-mochikabu | × | × | Web交付 |
+| ひふみ投信 | hifumi | - | × | 各種資料→取引報告書類等（売却なし時は発行なし） |
+| さわかみ投信 | sawakami | - | × | 資産状況→各種報告書（売却なし時は発行なし） |
+
+---
+
+## データ収集・保存設計
+
+### 収集方式
+
+**Playwright ブラウザ自動操作**（人間が手動でやってきた操作をSkill化）
+
+- `headless=False` で動作確認 → 安定後に headless 化
+- 各操作間は 1〜3 秒 wait（レート制限対策）
+- 2FA・CAPTCHA 検出時は即停止 → ユーザーに手動介入を依頼
+- 報告書が存在しない場合（売却なし等）は `skip` としてログに記録
+
+### 保存ディレクトリ構成
+
+```
+data/income/securities/
+└── <会社コード>/
+    └── <年度>/
+        ├── raw/               # ダウンロードした原本（コミット禁止）
+        │   ├── *.pdf
+        │   └── *.xml          # 公式XML（XMLあり会社のみ）
+        ├── nenkantorihikihokokusho.json     # 抽出済み構造化データ・全社共通（コミット禁止）
+        └── nenkantorihikihokokusho.xml      # 生成XML・PDFのみ会社のみ（コミット禁止）
+                               # ※nenkantorihikihokokusho.jsonと同構造・source="pdf_generated"で識別
+```
+
+### スキルディレクトリ構成
+
+```
+skills/tax-collect/
+├── SKILL.md
+├── registry.json              # 会社コード↔会社名の対応表・XMLあり/なし等（コミット可）
+└── sites/
+    └── <会社コード>/
+        ├── site.json          # サイト設定（コミット可）
+        └── collect.py         # Playwright収集スクリプト（コミット可）
+```
+
+### registry.json の構造
+
+```json
+{
+  "securities": [
+    { "code": "sbi",           "name": "SBI証券",              "url": "https://www.sbisec.co.jp/ETGate",                  "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
+    { "code": "rakuten",       "name": "楽天証券",              "url": "https://www.rakuten-sec.co.jp/",                   "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "nomura",        "name": "野村證券",              "url": "https://www.nomura.co.jp/",                        "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
+    { "code": "monex",         "name": "マネックス証券",        "url": "https://www.monex.co.jp/",                         "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
+    { "code": "matsui",        "name": "松井証券",              "url": "https://www.matsui.co.jp/",                        "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "gmo-click",     "name": "GMOクリック証券",       "url": "https://www.click-sec.com/",                       "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "smbc-nikko",    "name": "SMBC日興証券",          "url": "https://www.smbcnikko.co.jp/",                     "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "mufg-esmart",   "name": "三菱UFJ eスマート証券", "url": "https://kabu.com/",                                "has_xml": false, "マイナ連携": true,  "collection": "auto"   },
+    { "code": "tsumiki",       "name": "tsumiki証券",           "url": "https://www.tsumiki-sec.com/",                     "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "saison-pocket", "name": "セゾンポケット",        "url": "https://www.saison-pocket.com/",                   "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "daiwa-connect", "name": "大和CONNECT証券",       "url": "https://www.connect-sec.co.jp/service/login/",     "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "paypay",        "name": "PayPay証券",            "url": "https://www.paypay-sec.co.jp/",                    "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "webull",        "name": "ウィブル証券",          "url": null,                                               "has_xml": false, "マイナ連携": false, "collection": "manual" },
+    { "code": "nomura-mochikabu", "name": "野村證券持株会",     "url": "https://www.e-plan.nomura.co.jp/login/index.html", "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "hifumi",        "name": "ひふみ投信",            "url": "https://hifumi.rheos.jp/",                         "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "sawakami",      "name": "さわかみ投信",          "url": "https://fv.sawakami.co.jp/Account/Login",          "has_xml": false, "マイナ連携": false, "collection": "auto"   }
+  ]
+}
+```
+
+### site.json の構造
+
+```json
+{
+  "name": "楽天証券",
+  "code": "rakuten",
+  "has_xml": true,
+  "target_year": 2025,
+  "output_dir": "data/income/securities/rakuten/2025/raw/",
+  "documents": [
+    { "type": "特定口座年間取引報告書" }
+  ]
+}
+```
+
+### headless の制御
+
+環境変数 `HEADLESS` で制御する。未設定時は `false`（開発時デフォルト）。
+
+```bash
+# 開発時（目視確認）
+# 未設定 or HEADLESS=false
+
+# 自動実行時
+HEADLESS=true python collect.py
+```
+
+---
+
+## データ抽出・JSON化設計
+
+### XMLあり会社（e-Tax 標準 XML 形式 TEG204）
+
+国税庁の e-Tax XML（TEG204形式）を直接パース → `nenkantorihikihokokusho.json` に変換。
+
+```json
+{
+  "company": "楽天証券",
+  "code": "rakuten",
+  "year": 2025,
+  "document_type": "特定口座年間取引報告書",
+  "source": "xml",
+  "account": {
+    "口座種別": "源泉徴収あり特定口座",
+    "譲渡所得源泉徴収": true,
+    "配当所得源泉徴収": true,
+    "開設日": "2010-03-10"
+  },
+  "譲渡": {
+    "取引件数_上場株式等": 45912,
+    "取引件数_信用等": 14987,
+    "取引件数_一般株式等": 0,
+    "上場株式等": {
+      "譲渡の対価の額": 5509902,
+      "取得費及び譲渡に要した費用の額等": 5228252,
+      "差引金額_譲渡損益": 281650
+    },
+    "損益通算後": {
+      "所得控除の額の合計額": 0,
+      "差引所得税額": -18161,
+      "翌年繰越損失額": 18161
+    },
+    "合計": {
+      "課税標準": 5509902,
+      "取得費等": 5210091,
+      "差引損益": 299811
+    }
+  },
+  "配当等": {
+    "上場株式の配当等": {
+      "配当等の額": 133550,
+      "所得税": 20443,
+      "復興特別所得税": 6673,
+      "地方税": 0
+    },
+    "特定株式投資信託の収益の分配等": {
+      "配当等の額": 43349,
+      "所得税": 6637,
+      "復興特別所得税": 2166,
+      "地方税": 0
+    },
+    "一般株式等の配当等": {
+      "配当等の額": 173,
+      "所得税": 11,
+      "復興特別所得税": 6,
+      "地方税": 12
+    },
+    "投資信託等の収益の分配等": {
+      "配当等の額": 492285,
+      "所得税": 67833,
+      "復興特別所得税": 22135,
+      "地方税": 49220
+    },
+    "非居住者等への配当等": {
+      "配当等の額": 18802,
+      "所得税": 2875,
+      "復興特別所得税": 935,
+      "地方税": 5143
+    },
+    "外国株式等の配当等": {
+      "配当等の額": 0,
+      "外国所得税": 0
+    },
+    "NISA口座内の配当等": {
+      "配当等の額": 0
+    },
+    "合計": {
+      "配当等の額": 688159,
+      "所得税_源泉徴収税額": 97799,
+      "復興特別所得税": 31915,
+      "地方税": 49220,
+      "納付税額": 49220
+    }
+  },
+  "NISA": {
+    "譲渡等": {
+      "譲渡の対価の額": 0,
+      "取得費等": 0
+    }
+  },
+  "源泉徴収税額合計": {
+    "所得税": 97799,
+    "復興特別所得税": 31915
+  },
+  "証券会社": {
+    "名称": "楽天証券株式会社",
+    "法人番号": "5010701021660"
+  },
+  "raw_files": ["raw/2025_nentori.xml", "raw/20260406_xxx.pdf"],
+  "collected_at": "2026-04-06T23:15:50"
+}
+```
+
+### XMLなし会社（PDFのみ）
+
+PDFをClaude API（`claude-sonnet-4-6`）で解析 → 同フォーマットの `nenkantorihikihokokusho.json` に変換。
+
+```json
+{
+  "company": "tsumiki証券",
+  "code": "tsumiki",
+  "source": "pdf_ocr",
+  ...
+}
+```
+
+---
+
+## 実装 issue 案
+
+| # | 内容 | ラベル | 依存 |
+|---|---|---|---|
+| [#5](https://github.com/genba-neko/agent-skills-money-ops/issues/5) | tax-collect 基盤（registry.json・site.json読込・ディレクトリ管理・ログ） | `feat` | なし |
+| [#6](https://github.com/genba-neko/agent-skills-money-ops/issues/6) | TEG204 XML → nenkantorihikihokokusho.json 変換モジュール | `feat` | #5 |
+| [#7](https://github.com/genba-neko/agent-skills-money-ops/issues/7) | PDF → nenkantorihikihokokusho.json + .xml 変換モジュール（Claude API） | `feat` | #5 |
+| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 |
+| [#9](https://github.com/genba-neko/agent-skills-money-ops/issues/9) | XMLあり各社 Playwright収集スクリプト（楽天証券以外） | `feat` | #5 #6 #8 |
+| [#10](https://github.com/genba-neko/agent-skills-money-ops/issues/10) | PDFのみ各社 Playwright収集スクリプト | `feat` | #5 #7 |
+
+---
+
+## 決定事項まとめ
+
+| 項目 | 決定内容 |
+|---|---|
+| 最初に実装する会社 | 楽天証券（XMLあり） |
+| JSONキー名 | 日本語 |
+| headless制御 | 環境変数 `HEADLESS`（未設定時=false） |
+| テスト用fixtures | 匿名化したサンプルデータを別途用意 |

--- a/plan/initial_money_ops_plan.md
+++ b/plan/initial_money_ops_plan.md
@@ -23,6 +23,7 @@ Claude Code と Chrome 拡張連携を使って、普段の明細保存や家計
 |---|---|---|
 | [#1](https://github.com/genba-neko/agent-skills-money-ops/issues/1) | プロジェクト初期セットアップ（構成・CLAUDE.md・plugin.json） | [完了 PR#2 2026-04-11] |
 | [#3](https://github.com/genba-neko/agent-skills-money-ops/issues/3) | .work/除外と関連ルール整備 | [完了 PR#4 2026-04-11] |
+| [#11](https://github.com/genba-neko/agent-skills-money-ops/issues/11) | tax-collect スキル設計プランの追加 | [完了 PR#12 2026-04-11] |
 
 ---
 


### PR DESCRIPTION
## Summary

- 確定申告に必要な書類の定義
- 対象証券会社16社の一覧・URL・XMLあり/なし・収集方式（auto/manual）
- データ収集・保存設計（registry.json・site.json・ディレクトリ構成）
- nenkantorihikihokokusho.json / .xml のフォーマット定義
- 実装 issue 一覧（#5〜#10）登録済み

closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)