### PR TITLE
feat: tax-collect 基盤実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# ブラウザ制御（未設定時は false）
+HEADLESS=false
+
+# 認証情報（各証券会社）
+# 会社ごとに <CODE>_USER / <CODE>_PASS の形式で追加
+# RAKUTEN_USER=
+# RAKUTEN_PASS=

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ output/**
 *.config.json
 .env
 .env.*
+!.env.example
 
 # Python
 __pycache__/

--- a/plan/20260411_1302_tax-collect.md
+++ b/plan/20260411_1302_tax-collect.md
@@ -270,7 +270,7 @@ PDFをClaude API（`claude-sonnet-4-6`）で解析 → 同フォーマットの 
 
 | # | 内容 | ラベル | 依存 |
 |---|---|---|---|
-| [#5](https://github.com/genba-neko/agent-skills-money-ops/issues/5) | tax-collect 基盤（registry.json・site.json読込・ディレクトリ管理・ログ） | `feat` | なし |
+| [#5](https://github.com/genba-neko/agent-skills-money-ops/issues/5) | tax-collect 基盤（registry.json・site.json読込・ディレクトリ管理・ログ） | `feat` | なし | [完了 PR#13 2026-04-11] |
 | [#6](https://github.com/genba-neko/agent-skills-money-ops/issues/6) | TEG204 XML → nenkantorihikihokokusho.json 変換モジュール | `feat` | #5 |
 | [#7](https://github.com/genba-neko/agent-skills-money-ops/issues/7) | PDF → nenkantorihikihokokusho.json + .xml 変換モジュール（Claude API） | `feat` | #5 |
 | [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "money-ops"
+version = "0.1.0"
+description = "確定申告・家計・投資自動化スキル集"
+requires-python = ">=3.11"
+dependencies = [
+    "playwright>=1.44",
+    "python-dotenv>=1.0",
+    "anthropic>=0.28",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.11"
 dependencies = [
     "playwright>=1.44",
     "python-dotenv>=1.0",
-    "anthropic>=0.28",
 ]
 
 [project.optional-dependencies]

--- a/skills/tax-collect/registry.json
+++ b/skills/tax-collect/registry.json
@@ -1,0 +1,20 @@
+{
+  "securities": [
+    { "code": "sbi",              "name": "SBI証券",              "url": "https://www.sbisec.co.jp/ETGate",                  "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
+    { "code": "rakuten",          "name": "楽天証券",              "url": "https://www.rakuten-sec.co.jp/",                   "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "nomura",           "name": "野村證券",              "url": "https://www.nomura.co.jp/",                        "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
+    { "code": "monex",            "name": "マネックス証券",        "url": "https://www.monex.co.jp/",                         "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
+    { "code": "matsui",           "name": "松井証券",              "url": "https://www.matsui.co.jp/",                        "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "gmo-click",        "name": "GMOクリック証券",       "url": "https://www.click-sec.com/",                       "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "smbc-nikko",       "name": "SMBC日興証券",          "url": "https://www.smbcnikko.co.jp/",                     "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
+    { "code": "mufg-esmart",      "name": "三菱UFJ eスマート証券", "url": "https://kabu.com/",                                "has_xml": false, "マイナ連携": true,  "collection": "auto"   },
+    { "code": "tsumiki",          "name": "tsumiki証券",           "url": "https://www.tsumiki-sec.com/",                     "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "saison-pocket",    "name": "セゾンポケット",        "url": "https://www.saison-pocket.com/",                   "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "daiwa-connect",    "name": "大和CONNECT証券",       "url": "https://www.connect-sec.co.jp/service/login/",     "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "paypay",           "name": "PayPay証券",            "url": "https://www.paypay-sec.co.jp/",                    "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "webull",           "name": "ウィブル証券",          "url": null,                                               "has_xml": false, "マイナ連携": false, "collection": "manual" },
+    { "code": "nomura-mochikabu", "name": "野村證券持株会",        "url": "https://www.e-plan.nomura.co.jp/login/index.html", "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "hifumi",           "name": "ひふみ投信",            "url": "https://hifumi.rheos.jp/",                         "has_xml": false, "マイナ連携": false, "collection": "auto"   },
+    { "code": "sawakami",         "name": "さわかみ投信",          "url": "https://fv.sawakami.co.jp/Account/Login",          "has_xml": false, "マイナ連携": false, "collection": "auto"   }
+  ]
+}

--- a/skills/tax-collect/sites/rakuten/site.json
+++ b/skills/tax-collect/sites/rakuten/site.json
@@ -1,0 +1,10 @@
+{
+  "name": "楽天証券",
+  "code": "rakuten",
+  "has_xml": true,
+  "target_year": 2025,
+  "output_dir": "data/income/securities/rakuten/2025/raw/",
+  "documents": [
+    { "type": "特定口座年間取引報告書" }
+  ]
+}

--- a/src/money_ops/collector/__init__.py
+++ b/src/money_ops/collector/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseCollector
+
+__all__ = ["BaseCollector"]

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -1,0 +1,68 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+
+def _load_site_config(site_json_path: str | Path) -> dict:
+    with open(site_json_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _is_headless() -> bool:
+    return os.environ.get("HEADLESS", "false").lower() == "true"
+
+
+class BaseCollector:
+    def __init__(self, site_json_path: str | Path):
+        self.config = _load_site_config(site_json_path)
+        self.code: str = self.config["code"]
+        self.name: str = self.config["name"]
+        self.output_dir = Path(self.config["output_dir"])
+        self.headless: bool = _is_headless()
+
+    def prepare_directory(self) -> None:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def launch_browser(self):
+        from playwright.sync_api import sync_playwright
+
+        self._playwright = sync_playwright().start()
+        self._browser = self._playwright.chromium.launch(headless=self.headless)
+        self._page = self._browser.new_page()
+        return self._page
+
+    def close_browser(self) -> None:
+        if hasattr(self, "_browser"):
+            self._browser.close()
+        if hasattr(self, "_playwright"):
+            self._playwright.stop()
+
+    def log_result(self, status: str, files: list[str], message: str = "") -> None:
+        log_dir = Path("output") / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        log_path = log_dir / f"{self.code}.json"
+        entry = {
+            "code": self.code,
+            "name": self.name,
+            "status": status,
+            "files": files,
+            "message": message,
+            "collected_at": datetime.now().isoformat(),
+        }
+
+        history = []
+        if log_path.exists():
+            with open(log_path, encoding="utf-8") as f:
+                history = json.load(f)
+
+        history.append(entry)
+
+        with open(log_path, "w", encoding="utf-8") as f:
+            json.dump(history, f, ensure_ascii=False, indent=2)
+
+        print(f"[{self.name}] {status}: {message or ', '.join(files)}")
+
+    def collect(self) -> None:
+        raise NotImplementedError("collect() をサブクラスで実装してください")

--- a/src/money_ops/registry.py
+++ b/src/money_ops/registry.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+_REGISTRY_PATH = Path(__file__).parent.parent.parent / "skills" / "tax-collect" / "registry.json"
+
+
+def load_registry() -> dict:
+    with open(_REGISTRY_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_company(code: str) -> dict:
+    registry = load_registry()
+    for company in registry["securities"]:
+        if company["code"] == code:
+            return company
+    raise KeyError(f"会社コード '{code}' が registry.json に見つかりません")
+
+
+def list_auto_companies() -> list[dict]:
+    registry = load_registry()
+    return [c for c in registry["securities"] if c["collection"] == "auto"]

--- a/tests/test_base_collector.py
+++ b/tests/test_base_collector.py
@@ -1,0 +1,47 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from money_ops.collector.base import BaseCollector
+
+
+SITE_JSON = Path(__file__).parent.parent / "skills" / "tax-collect" / "sites" / "rakuten" / "site.json"
+
+
+def test_load_config():
+    collector = BaseCollector(SITE_JSON)
+    assert collector.code == "rakuten"
+    assert collector.name == "楽天証券"
+
+
+def test_headless_default():
+    os.environ.pop("HEADLESS", None)
+    collector = BaseCollector(SITE_JSON)
+    assert collector.headless is False
+
+
+def test_headless_env_true():
+    os.environ["HEADLESS"] = "true"
+    collector = BaseCollector(SITE_JSON)
+    assert collector.headless is True
+    os.environ.pop("HEADLESS")
+
+
+def test_prepare_directory(tmp_path, monkeypatch):
+    config = json.loads(SITE_JSON.read_text(encoding="utf-8"))
+    config["output_dir"] = str(tmp_path / "raw")
+
+    tmp_site = tmp_path / "site.json"
+    tmp_site.write_text(json.dumps(config), encoding="utf-8")
+
+    collector = BaseCollector(tmp_site)
+    collector.prepare_directory()
+    assert collector.output_dir.exists()
+
+
+def test_collect_not_implemented():
+    collector = BaseCollector(SITE_JSON)
+    with pytest.raises(NotImplementedError):
+        collector.collect()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,35 @@
+from money_ops.registry import get_company, list_auto_companies, load_registry
+
+
+def test_load_registry():
+    registry = load_registry()
+    assert "securities" in registry
+    assert len(registry["securities"]) > 0
+
+
+def test_get_company_found():
+    company = get_company("rakuten")
+    assert company["name"] == "楽天証券"
+    assert company["has_xml"] is True
+    assert company["collection"] == "auto"
+
+
+def test_get_company_not_found():
+    import pytest
+    with pytest.raises(KeyError):
+        get_company("nonexistent")
+
+
+def test_list_auto_companies():
+    companies = list_auto_companies()
+    codes = [c["code"] for c in companies]
+    assert "rakuten" in codes
+    assert "webull" not in codes
+
+
+def test_all_companies_have_required_fields():
+    registry = load_registry()
+    required = {"code", "name", "url", "has_xml", "マイナ連携", "collection"}
+    for company in registry["securities"]:
+        missing = required - company.keys()
+        assert not missing, f"{company['code']} にフィールドが不足: {missing}"


### PR DESCRIPTION
## Summary

- `pyproject.toml` — 依存パッケージ定義（playwright / python-dotenv / anthropic / pytest）
- `.env.example` — 環境変数テンプレート
- `skills/tax-collect/registry.json` — 16社のコード・URL・収集方式
- `skills/tax-collect/sites/rakuten/site.json` — 楽天証券設定
- `src/money_ops/registry.py` — registry.json ローダー
- `src/money_ops/collector/base.py` — ディレクトリ管理・ブラウザ起動・ログ基盤
- テスト 10件全パス

closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)