### PR TITLE
feat: 楽天証券 Playwright収集スクリプト実装 (#8)

### DIFF
--- a/plan/20260411_1302_tax-collect.md
+++ b/plan/20260411_1302_tax-collect.md
@@ -273,7 +273,7 @@ PDFをClaude API（`claude-sonnet-4-6`）で解析 → 同フォーマットの 
 | [#5](https://github.com/genba-neko/agent-skills-money-ops/issues/5) | tax-collect 基盤（registry.json・site.json読込・ディレクトリ管理・ログ） | `feat` | なし | [完了 PR#13 2026-04-11] |
 | [#6](https://github.com/genba-neko/agent-skills-money-ops/issues/6) | TEG204 XML → nenkantorihikihokokusho.json 変換モジュール | `feat` | #5 | [完了 PR#14 2026-04-11] |
 | [#7](https://github.com/genba-neko/agent-skills-money-ops/issues/7) | PDF → nenkantorihikihokokusho.json + .xml 変換モジュール（Claude API） | `feat` | #5 | [完了 PR#16 2026-04-11] |
-| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 |
+| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 | [完了 PR#XX 2026-04-11] |
 | [#9](https://github.com/genba-neko/agent-skills-money-ops/issues/9) | XMLあり各社 Playwright収集スクリプト（楽天証券以外） | `feat` | #5 #6 #8 |
 | [#10](https://github.com/genba-neko/agent-skills-money-ops/issues/10) | PDFのみ各社 Playwright収集スクリプト | `feat` | #5 #7 |
 

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -1,0 +1,226 @@
+"""楽天証券 特定口座年間取引報告書（PDF + XML）Playwright 収集スクリプト
+
+使い方:
+    python collect.py [--year YYYY]
+
+環境変数:
+    HEADLESS    true/false（デフォルト: false）
+
+注意:
+    ログイン・絵文字認証は人間が手動で行う。
+    スクリプト起動後、ブラウザでログインを完了してから Enter を押すこと。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+from money_ops.collector.base import BaseCollector
+from money_ops.converter.xml_to_json import convert_teg204_xml
+
+_SITE_JSON = Path(__file__).parent / "site.json"
+_LOGIN_URL = "https://www.rakuten-sec.co.jp/"
+
+
+def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
+    time.sleep(random.uniform(lo, hi))
+
+
+class RakutenCollector(BaseCollector):
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
+        super().__init__(site_json_path)
+        if year is not None:
+            self.config["target_year"] = year
+            self.config["output_dir"] = f"data/income/securities/rakuten/{year}/raw/"
+            self.output_dir = Path(self.config["output_dir"])
+
+    # ------------------------------------------------------------------
+    # 手動ログイン待機
+    # ------------------------------------------------------------------
+    def _wait_for_login(self, page) -> None:
+        page.goto(_LOGIN_URL)
+        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）")
+        input("ログイン完了後、Enter を押してください: ")
+        _wait()
+
+    # ------------------------------------------------------------------
+    # 電子書面一覧ページへ移動
+    # ------------------------------------------------------------------
+    def _navigate_to_report_list(self, page) -> None:
+        year = self.config["target_year"]
+        print(f"[{self.name}] 確定申告サポート → 取引報告書等(電子書面) へ移動")
+        page.get_by_role("button", name="マイメニュー 口座管理・入出金など").click()
+        _wait()
+        page.get_by_role("link", name="確定申告サポート").click()
+        _wait()
+        page.get_by_role("link", name=f"{year}年").click()
+        _wait()
+        page.get_by_role("link", name="取引報告書等(電子書面)").first.click()
+        _wait()
+
+    # ------------------------------------------------------------------
+    # 対象年度の行を特定してダウンロード
+    # ------------------------------------------------------------------
+    def _download_files(self, page) -> list[str]:
+        self.prepare_directory()
+        year = self.config["target_year"]
+        downloaded: list[str] = []
+
+        # 対象年度の行: <tr> の中に <span>{year}</span> を含む行
+        year_row = page.locator(f"tr:has(td span:text-is('{year}'))")
+        if year_row.count() == 0:
+            print(f"[{self.name}] {year}年の行が見つかりません")
+            return downloaded
+
+        # ---- XML ダウンロード ----
+        xml_button = year_row.get_by_role("button", name="XML保存")
+        if xml_button.count() > 0:
+            with page.expect_download() as dl_info:
+                xml_button.click()
+            dl = dl_info.value
+            xml_path = self.output_dir / dl.suggested_filename
+            dl.save_as(str(xml_path))
+            downloaded.append(str(xml_path))
+            print(f"[{self.name}] XML 保存: {xml_path}")
+            _wait()
+        else:
+            print(f"[{self.name}] {year}年の XML保存ボタンが見つかりません")
+
+        # ---- PDF ダウンロード ----
+        # B0020.aspx が PDF を返すが Chrome の PDF ビューア拡張が先にインターセプト
+        # するため response リスナーには HTML ラッパーが届く。
+        # context.route() で拡張処理前に PDF バイトを捕捉する。
+        pdf_link = year_row.get_by_role("link", name="PDF表示")
+        if pdf_link.count() > 0:
+            pdf_bytes_holder: list[bytes] = []
+
+            def _route_pdf(route, request) -> None:
+                # chrome-extension:// 等は fetch 不可なのでスキップ
+                if not request.url.startswith(("http://", "https://")):
+                    route.continue_()
+                    return
+                response = route.fetch()
+                ct = response.headers.get("content-type", "")
+                if "application/pdf" in ct and response.status == 200:
+                    try:
+                        # Content-Disposition からオリジナルファイル名を取得
+                        cd = response.headers.get("content-disposition", "")
+                        import re as _re
+                        m = _re.search(r'filename[^;=\n]*=([^;\n]*)', cd)
+                        fn = m.group(1).strip().strip('"\'') if m else ""
+                        if not fn:
+                            fn = request.url.rstrip("/").split("/")[-1].split("?")[0]
+                        if not fn.lower().endswith(".pdf"):
+                            fn = f"{fn}.pdf" if fn else f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_nentori.pdf"
+                        pdf_bytes_holder.append((fn, response.body()))
+                    except Exception as e:
+                        print(f"[{self.name}] PDF body取得失敗: {e}")
+                route.fulfill(response=response)
+
+            page.context.route("https://report.rakuten-sec.co.jp/**", _route_pdf)
+            try:
+                with page.expect_popup() as popup_info:
+                    pdf_link.click()
+                popup = popup_info.value
+                popup.wait_for_load_state("networkidle")
+                _wait()
+                popup.close()
+            finally:
+                page.context.unroute("https://report.rakuten-sec.co.jp/**", _route_pdf)
+
+            if pdf_bytes_holder:
+                pdf_filename, pdf_bytes = pdf_bytes_holder[0]
+                pdf_path = self.output_dir / pdf_filename
+                pdf_path.write_bytes(pdf_bytes)
+                downloaded.append(str(pdf_path))
+                print(f"[{self.name}] PDF 保存: {pdf_path}")
+            else:
+                print(f"[{self.name}] PDF レスポンスを捕捉できませんでした")
+            _wait()
+        else:
+            print(f"[{self.name}] {year}年の PDF表示リンクが見つかりません")
+
+        return downloaded
+
+    # ------------------------------------------------------------------
+    # JSON 変換
+    # ------------------------------------------------------------------
+    def _convert_to_json(self, downloaded_files: list[str]) -> None:
+        year = self.config["target_year"]
+        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
+        if not xml_files:
+            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
+            return
+
+        raw_files = [str(Path(f).name) for f in downloaded_files]
+        data = convert_teg204_xml(
+            xml_path=xml_files[0],
+            company=self.name,
+            code=self.code,
+            year=year,
+            raw_files=raw_files,
+        )
+
+        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        print(f"[{self.name}] JSON 保存: {json_path}")
+
+    # ------------------------------------------------------------------
+    # メイン収集フロー
+    # ------------------------------------------------------------------
+    def collect(self) -> None:
+        page = self.launch_browser()
+        try:
+            self._wait_for_login(page)
+            self._navigate_to_report_list(page)
+
+            year = self.config["target_year"]
+            if page.locator(f"tr:has(td span:text-is('{year}'))").count() == 0:
+                self.log_result("skip", [], f"{year}年の取引報告書が存在しません")
+                return
+
+            downloaded = self._download_files(page)
+
+            if not downloaded:
+                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+                return
+
+            self._convert_to_json(downloaded)
+            self.log_result("success", downloaded)
+
+        except KeyboardInterrupt:
+            print(f"\n[{self.name}] ユーザーによる中断")
+            self.log_result("interrupted", [], "ユーザーによる中断")
+        except Exception as e:
+            print(f"[{self.name}] エラー: {e}")
+            self.log_result("error", [], str(e))
+            raise
+        finally:
+            self.close_browser()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="楽天証券 年間取引報告書収集")
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=None,
+        help="対象年度（未指定時は site.json の target_year を使用）",
+    )
+    args = parser.parse_args()
+    collector = RakutenCollector(year=args.year)
+    collector.collect()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/rakuten_elect_del_top.html
+++ b/tests/fixtures/rakuten_elect_del_top.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>取引報告書等（電子書面）</title>
+</head>
+<body>
+<table>
+  <thead>
+    <tr>
+      <th scope="col"><span>書類名</span></th>
+      <th scope="col"><span>年</span></th>
+      <th scope="col"><span>取引件数</span></th>
+      <th scope="col"><span>譲渡損益</span></th>
+      <th scope="col"><span>配当等</span></th>
+      <th scope="col"><span>源泉徴収税額</span></th>
+      <th scope="col"><span>本照合</span></th>
+      <th scope="col"><span>電子書面</span></th>
+      <th scope="col"><span>CSV/XML</span></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="1"><span>特定口座年間取引報告書</span></td>
+      <td rowspan="1"><span>2025</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td rowspan="1">
+        <span class="pcmm--is-clr-font-strong-id" id="196876353">本照合</span>
+      </td>
+      <td rowspan="1">
+        <a href="javascript:void(0);" onclick="browseRpt('196876353', '001','20251231','', '1', '', '1', '702', '518455', '01'); return false;" class="pcmm-btlk-link" target="_blank" rel="noopener">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-pdf-outline" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">PDF表示</span>
+        </a>
+      </td>
+      <td rowspan="1">
+        <button type="button" class="pcmm-btlk-link" onclick="dlXmlSpaYearyRpt('2025', '20251231', '702', '518455', '001'); return false;" data-ratId="mem_pc_denshishomen_nentori-xml" data-ratEvent="click" data-ratParam="all">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-download-filled" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">XML保存</span>
+        </button>
+      </td>
+    </tr>
+    <tr data-tr-group="even">
+      <td rowspan="1"><span>特定口座年間取引報告書</span></td>
+      <td rowspan="1"><span>2024</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td rowspan="1">
+        <span class="pcmm--is-clr-font-strong-id" id="165812116">本照合</span>
+      </td>
+      <td rowspan="1">
+        <a href="javascript:void(0);" onclick="browseRpt('165812116', '001','20241231','', '1', '', '1', '702', '518455', '01'); return false;" class="pcmm-btlk-link" target="_blank" rel="noopener">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-pdf-outline" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">PDF表示</span>
+        </a>
+      </td>
+      <td rowspan="1">
+        <button type="button" class="pcmm-btlk-link" onclick="dlXmlSpaYearyRpt('2024', '20241231', '702', '518455', '001'); return false;" data-ratId="mem_pc_denshishomen_nentori-xml" data-ratEvent="click" data-ratParam="all">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-download-filled" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">XML保存</span>
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="1"><span>特定口座年間取引報告書</span></td>
+      <td rowspan="1"><span>2023</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td rowspan="1">
+        <span class="pcmm--is-clr-font-strong-id" id="140000001">本照合</span>
+      </td>
+      <td rowspan="1">
+        <a href="javascript:void(0);" onclick="browseRpt('140000001', '001','20231231','', '1', '', '1', '702', '518455', '01'); return false;" class="pcmm-btlk-link" target="_blank" rel="noopener">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-pdf-outline" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">PDF表示</span>
+        </a>
+      </td>
+      <td rowspan="1">
+        <button type="button" class="pcmm-btlk-link" onclick="dlXmlSpaYearyRpt('2023', '20231231', '702', '518455', '001'); return false;" data-ratId="mem_pc_denshishomen_nentori-xml" data-ratEvent="click" data-ratParam="all">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-download-filled" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">XML保存</span>
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -1,0 +1,277 @@
+"""楽天証券収集スクリプトのユニットテスト（Playwright モック）"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+_SITE_JSON = _PROJECT_ROOT / "skills" / "tax-collect" / "sites" / "rakuten" / "site.json"
+
+import importlib.util
+
+_COLLECT_PY = _PROJECT_ROOT / "skills" / "tax-collect" / "sites" / "rakuten" / "collect.py"
+_spec = importlib.util.spec_from_file_location("rakuten_collect", _COLLECT_PY)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+RakutenCollector = _mod.RakutenCollector
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_collector(tmp_path: Path, year: int = 2025) -> RakutenCollector:
+    config = json.loads(_SITE_JSON.read_text(encoding="utf-8"))
+    config["output_dir"] = str(tmp_path / "raw")
+    config["target_year"] = year
+    tmp_site = tmp_path / "site.json"
+    tmp_site.write_text(json.dumps(config), encoding="utf-8")
+    # year=None で渡して config の値を使わせる（output_dir 上書きを防ぐ）
+    return RakutenCollector(site_json_path=tmp_site)
+
+
+# ---------------------------------------------------------------------------
+# 初期化テスト
+# ---------------------------------------------------------------------------
+
+def test_init_default_year(tmp_path):
+    collector = _make_collector(tmp_path)
+    assert collector.config["target_year"] == 2025
+    assert collector.code == "rakuten"
+    assert collector.name == "楽天証券"
+
+
+def test_init_override_year(tmp_path):
+    collector = _make_collector(tmp_path, year=2024)
+    assert collector.config["target_year"] == 2024
+    assert collector.output_dir == tmp_path / "raw"
+
+
+# ---------------------------------------------------------------------------
+# 手動ログイン待機テスト
+# ---------------------------------------------------------------------------
+
+def test_wait_for_login(tmp_path):
+    collector = _make_collector(tmp_path)
+    page = MagicMock()
+
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        collector._wait_for_login(page)
+
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+# ---------------------------------------------------------------------------
+# ナビゲーションテスト
+# ---------------------------------------------------------------------------
+
+def test_navigate_to_report_list(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+
+    calls = []
+
+    def get_by_role_side(role, **kwargs):
+        calls.append((role, kwargs.get("name", "")))
+        return MagicMock()
+
+    page.get_by_role.side_effect = get_by_role_side
+
+    with patch.object(_mod, "_wait"):
+        collector._navigate_to_report_list(page)
+
+    names = [name for _, name in calls]
+    assert "マイメニュー 口座管理・入出金など" in names
+    assert "確定申告サポート" in names
+    assert "2025年" in names
+    assert "取引報告書等(電子書面)" in names
+
+
+# ---------------------------------------------------------------------------
+# ダウンロードテスト
+# ---------------------------------------------------------------------------
+
+def _make_download_mock(saved_paths: list, content: bytes = b"dummy"):
+    dl = MagicMock()
+
+    def save_as(path):
+        saved_paths.append(path)
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(content)
+
+    dl.value.save_as = save_as
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=dl)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def test_download_files_xml_and_pdf(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    saved: list[str] = []
+
+    page = MagicMock()
+    context = MagicMock()
+    page.context = context
+
+    # 年度行あり
+    year_row = MagicMock()
+    year_row.count.return_value = 1
+
+    xml_button = MagicMock()
+    xml_button.count.return_value = 1
+    pdf_link = MagicMock()
+    pdf_link.count.return_value = 1
+
+    def get_by_role_side(role, **kwargs):
+        name = kwargs.get("name", "")
+        if "XML" in name:
+            return xml_button
+        return pdf_link
+
+    year_row.get_by_role.side_effect = get_by_role_side
+    page.locator.return_value = year_row
+
+    # XML ダウンロード: suggested_filename を返す
+    dl_mock = MagicMock()
+    dl_mock.suggested_filename = "1234-Z00-00000000001.xml"
+
+    def save_as_side(path):
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(b"<xml/>")
+        saved.append(path)
+
+    dl_mock.save_as.side_effect = save_as_side
+    dl_cm = MagicMock()
+    dl_cm.__enter__ = MagicMock(return_value=MagicMock(value=dl_mock))
+    dl_cm.__exit__ = MagicMock(return_value=False)
+    page.expect_download.return_value = dl_cm
+
+    # PDF ポップアップ
+    popup = MagicMock()
+    popup_cm = MagicMock()
+    popup_cm.__enter__ = MagicMock(return_value=MagicMock(value=popup))
+    popup_cm.__exit__ = MagicMock(return_value=False)
+    page.expect_popup.return_value = popup_cm
+
+    # route ハンドラが呼ばれたとき PDF を注入
+    def context_route_side(pattern, handler):
+        # ハンドラを即時呼び出してPDFバイトを注入
+        route = MagicMock()
+        response = MagicMock()
+        response.headers = {"content-type": "application/pdf"}
+        response.status = 200
+        response.body.return_value = b"%PDF-dummy"
+        route.fetch.return_value = response
+        request = MagicMock()
+        request.url = "https://report.rakuten-sec.co.jp/web/index.aspx"
+        handler(route, request)
+
+    context.route.side_effect = context_route_side
+
+    with patch.object(_mod, "_wait"):
+        result = collector._download_files(page)
+
+    # XML は保存される
+    assert any(".xml" in p for p in saved)
+    # PDF は保存される
+    assert any(".pdf" in p for p in result)
+
+
+def test_download_files_year_row_not_found(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+    page.locator.return_value.count.return_value = 0
+
+    with patch.object(_mod, "_wait"):
+        result = collector._download_files(page)
+
+    assert result == []
+
+
+def test_download_files_no_xml_button(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+
+    year_row = MagicMock()
+    year_row.count.return_value = 1
+    page.locator.return_value = year_row
+
+    xml_button = MagicMock()
+    xml_button.count.return_value = 0
+    pdf_link = MagicMock()
+    pdf_link.count.return_value = 0
+
+    def get_by_role_side(role, **kwargs):
+        name = kwargs.get("name", "")
+        if "XML" in name:
+            return xml_button
+        return pdf_link
+
+    year_row.get_by_role.side_effect = get_by_role_side
+
+    with patch.object(_mod, "_wait"):
+        result = collector._download_files(page)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# JSON 変換テスト
+# ---------------------------------------------------------------------------
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    collector = _make_collector(tmp_path)
+    collector._convert_to_json(["data/foo.pdf"])
+    captured = capsys.readouterr()
+    assert "スキップ" in captured.out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    fixture_xml = _PROJECT_ROOT / "tests" / "fixtures" / "teg204_sample.xml"
+    if not fixture_xml.exists():
+        pytest.skip("teg204_sample.xml が存在しません")
+
+    collector = _make_collector(tmp_path)
+    collector.output_dir.mkdir(parents=True, exist_ok=True)
+    collector._convert_to_json([str(fixture_xml)])
+
+    json_path = collector.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == "rakuten"
+    assert data["source"] == "xml"
+
+
+# ---------------------------------------------------------------------------
+# collect() スキップフロー
+# ---------------------------------------------------------------------------
+
+def test_collect_skip_when_year_row_not_found(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+
+    def locator_side_effect(selector):
+        m = MagicMock()
+        m.count.return_value = 0
+        m.filter.return_value.count.return_value = 0
+        return m
+
+    page.locator.side_effect = locator_side_effect
+
+    with patch.object(collector, "launch_browser", return_value=page), \
+         patch.object(collector, "close_browser"), \
+         patch.object(collector, "_wait_for_login"), \
+         patch.object(collector, "_navigate_to_report_list"), \
+         patch.object(collector, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        collector.collect()
+
+    mock_log.assert_called_once_with("skip", [], f"{collector.config['target_year']}年の取引報告書が存在しません")

--- a/tests/test_rakuten_selectors.py
+++ b/tests/test_rakuten_selectors.py
@@ -1,0 +1,112 @@
+"""楽天証券 電子書面ページのセレクタ検証テスト（実際のDOM構造を使用）
+
+fixtures/rakuten_elect_del_top.html を Playwright でロードし、
+collect.py が使うセレクタが実際に動作することを確認する。
+
+実機確認済み情報（2026-04-11）:
+- 電子書面一覧: https://member.rakuten-sec.co.jp/app/acc_elect_del_top.do
+- PDF ポップアップ: https://report.rakuten-sec.co.jp/web/B0020.aspx
+- PDF 本体レスポンス: https://report.rakuten-sec.co.jp/web/index.aspx (application/pdf)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_HTML = Path(__file__).parent / "fixtures" / "rakuten_elect_del_top.html"
+
+
+@pytest.fixture(scope="module")
+def page():
+    """Playwright ページを返す fixture"""
+    from playwright.sync_api import sync_playwright
+
+    pw = sync_playwright().start()
+    browser = pw.chromium.launch(headless=True)
+    p = browser.new_page()
+    yield p
+    browser.close()
+    pw.stop()
+
+
+def _load(page):
+    page.goto(_FIXTURE_HTML.as_uri())
+
+
+# ---------------------------------------------------------------------------
+# 年度行の特定
+# ---------------------------------------------------------------------------
+
+def test_year_row_2025_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('2025'))")
+    assert rows.count() == 1
+
+
+def test_year_row_2024_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('2024'))")
+    assert rows.count() == 1
+
+
+def test_year_row_2023_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('2023'))")
+    assert rows.count() == 1
+
+
+def test_year_row_9999_not_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('9999'))")
+    assert rows.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 2025年行の XML保存・PDF表示ボタン
+# ---------------------------------------------------------------------------
+
+def test_2025_xml_button_found(page):
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2025'))")
+    xml_btn = year_row.get_by_role("button", name="XML保存")
+    assert xml_btn.count() == 1
+
+
+def test_2025_pdf_link_found(page):
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2025'))")
+    pdf_link = year_row.get_by_role("link", name="PDF表示")
+    assert pdf_link.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 年度をまたいで誤クリックしないことの確認
+# ---------------------------------------------------------------------------
+
+def test_2025_xml_button_not_2024(page):
+    """2025年行のXML保存ボタンが2024年のものでないことを確認"""
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2025'))")
+    xml_btn = year_row.get_by_role("button", name="XML保存")
+    onclick = xml_btn.get_attribute("onclick")
+    assert "'2025'" in onclick
+    assert "'2024'" not in onclick
+
+
+def test_2024_xml_button_not_2025(page):
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2024'))")
+    xml_btn = year_row.get_by_role("button", name="XML保存")
+    onclick = xml_btn.get_attribute("onclick")
+    assert "'2024'" in onclick
+    assert "'2025'" not in onclick
+
+
+def test_first_xml_button_is_not_reliable(page):
+    """ページ全体の最初のXML保存が必ずしも対象年度とは限らないことを確認"""
+    _load(page)
+    all_xml = page.get_by_role("button", name="XML保存")
+    assert all_xml.count() == 3  # 2025, 2024, 2023 の3行ある
+    # .first は 2025年だが、年度が変われば壊れる → 年度特定が必要


### PR DESCRIPTION
## Summary

- 手動ログイン待機方式（絵文字認証はユーザーが手動操作）
- 年度指定で対象行を特定してXML・PDFをダウンロード（全年度混在ページに対応）
- PDFは `context.route()` で Chrome PDFビューア拡張より前に捕捉
- XML・PDFともにサーバーのオリジナルファイル名を使用（`suggested_filename` / `Content-Disposition`）
- TEG204 XML → `nenkantorihikihokokusho.json` 変換
- 実際のDOMフィクスチャ（`rakuten_elect_del_top.html`）によるセレクタ検証テスト追加
- 実機動作確認済み（XML・PDF・JSON すべて正常保存）

## Test plan

- [ ] `python -m pytest` 56件全パス確認
- [ ] `python skills/tax-collect/sites/rakuten/collect.py --year 2025` 実機動作確認

## 関連

- Closes #8
- 関連プラン: [plan/20260411_1302_tax-collect.md](plan/20260411_1302_tax-collect.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)