### PR TITLE
fix: TEG204 XML名前空間・ネスト構造対応（issue #6 bugfix）

### DIFF
--- a/plan/20260411_1302_tax-collect.md
+++ b/plan/20260411_1302_tax-collect.md
@@ -271,9 +271,9 @@ PDFをClaude API（`claude-sonnet-4-6`）で解析 → 同フォーマットの 
 | # | 内容 | ラベル | 依存 |
 |---|---|---|---|
 | [#5](https://github.com/genba-neko/agent-skills-money-ops/issues/5) | tax-collect 基盤（registry.json・site.json読込・ディレクトリ管理・ログ） | `feat` | なし | [完了 PR#13 2026-04-11] |
-| [#6](https://github.com/genba-neko/agent-skills-money-ops/issues/6) | TEG204 XML → nenkantorihikihokokusho.json 変換モジュール | `feat` | #5 | [完了 PR#14 2026-04-11] |
+| [#6](https://github.com/genba-neko/agent-skills-money-ops/issues/6) | TEG204 XML → nenkantorihikihokokusho.json 変換モジュール | `feat` | #5 | [完了 PR#14 2026-04-11] / [bugfix PR#XX 2026-04-11] |
 | [#7](https://github.com/genba-neko/agent-skills-money-ops/issues/7) | PDF → nenkantorihikihokokusho.json + .xml 変換モジュール（Claude API） | `feat` | #5 | [完了 PR#16 2026-04-11] |
-| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 | [完了 PR#XX 2026-04-11] |
+| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 | [完了 PR#19 2026-04-11] |
 | [#9](https://github.com/genba-neko/agent-skills-money-ops/issues/9) | XMLあり各社 Playwright収集スクリプト（楽天証券以外） | `feat` | #5 #6 #8 |
 | [#10](https://github.com/genba-neko/agent-skills-money-ops/issues/10) | PDFのみ各社 Playwright収集スクリプト | `feat` | #5 #7 |
 

--- a/plan/20260411_1302_tax-collect.md
+++ b/plan/20260411_1302_tax-collect.md
@@ -273,7 +273,7 @@ PDFをClaude API（`claude-sonnet-4-6`）で解析 → 同フォーマットの 
 | [#5](https://github.com/genba-neko/agent-skills-money-ops/issues/5) | tax-collect 基盤（registry.json・site.json読込・ディレクトリ管理・ログ） | `feat` | なし | [完了 PR#13 2026-04-11] |
 | [#6](https://github.com/genba-neko/agent-skills-money-ops/issues/6) | TEG204 XML → nenkantorihikihokokusho.json 変換モジュール | `feat` | #5 | [完了 PR#14 2026-04-11] |
 | [#7](https://github.com/genba-neko/agent-skills-money-ops/issues/7) | PDF → nenkantorihikihokokusho.json + .xml 変換モジュール（Claude API） | `feat` | #5 | [完了 PR#16 2026-04-11] |
-| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 |
+| [#8](https://github.com/genba-neko/agent-skills-money-ops/issues/8) | 楽天証券 Playwright収集スクリプト（XMLあり・最初の実装） | `feat` | #5 #6 | [完了 PR#XX 2026-04-11] |
 | [#9](https://github.com/genba-neko/agent-skills-money-ops/issues/9) | XMLあり各社 Playwright収集スクリプト（楽天証券以外） | `feat` | #5 #6 #8 |
 | [#10](https://github.com/genba-neko/agent-skills-money-ops/issues/10) | PDFのみ各社 Playwright収集スクリプト | `feat` | #5 #7 |
 

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -1,0 +1,226 @@
+"""楽天証券 特定口座年間取引報告書（PDF + XML）Playwright 収集スクリプト
+
+使い方:
+    python collect.py [--year YYYY]
+
+環境変数:
+    HEADLESS    true/false（デフォルト: false）
+
+注意:
+    ログイン・絵文字認証は人間が手動で行う。
+    スクリプト起動後、ブラウザでログインを完了してから Enter を押すこと。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+from money_ops.collector.base import BaseCollector
+from money_ops.converter.xml_to_json import convert_teg204_xml
+
+_SITE_JSON = Path(__file__).parent / "site.json"
+_LOGIN_URL = "https://www.rakuten-sec.co.jp/"
+
+
+def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
+    time.sleep(random.uniform(lo, hi))
+
+
+class RakutenCollector(BaseCollector):
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
+        super().__init__(site_json_path)
+        if year is not None:
+            self.config["target_year"] = year
+            self.config["output_dir"] = f"data/income/securities/rakuten/{year}/raw/"
+            self.output_dir = Path(self.config["output_dir"])
+
+    # ------------------------------------------------------------------
+    # 手動ログイン待機
+    # ------------------------------------------------------------------
+    def _wait_for_login(self, page) -> None:
+        page.goto(_LOGIN_URL)
+        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）")
+        input("ログイン完了後、Enter を押してください: ")
+        _wait()
+
+    # ------------------------------------------------------------------
+    # 電子書面一覧ページへ移動
+    # ------------------------------------------------------------------
+    def _navigate_to_report_list(self, page) -> None:
+        year = self.config["target_year"]
+        print(f"[{self.name}] 確定申告サポート → 取引報告書等(電子書面) へ移動")
+        page.get_by_role("button", name="マイメニュー 口座管理・入出金など").click()
+        _wait()
+        page.get_by_role("link", name="確定申告サポート").click()
+        _wait()
+        page.get_by_role("link", name=f"{year}年").click()
+        _wait()
+        page.get_by_role("link", name="取引報告書等(電子書面)").first.click()
+        _wait()
+
+    # ------------------------------------------------------------------
+    # 対象年度の行を特定してダウンロード
+    # ------------------------------------------------------------------
+    def _download_files(self, page) -> list[str]:
+        self.prepare_directory()
+        year = self.config["target_year"]
+        downloaded: list[str] = []
+
+        # 対象年度の行: <tr> の中に <span>{year}</span> を含む行
+        year_row = page.locator(f"tr:has(td span:text-is('{year}'))")
+        if year_row.count() == 0:
+            print(f"[{self.name}] {year}年の行が見つかりません")
+            return downloaded
+
+        # ---- XML ダウンロード ----
+        xml_button = year_row.get_by_role("button", name="XML保存")
+        if xml_button.count() > 0:
+            with page.expect_download() as dl_info:
+                xml_button.click()
+            dl = dl_info.value
+            xml_path = self.output_dir / dl.suggested_filename
+            dl.save_as(str(xml_path))
+            downloaded.append(str(xml_path))
+            print(f"[{self.name}] XML 保存: {xml_path}")
+            _wait()
+        else:
+            print(f"[{self.name}] {year}年の XML保存ボタンが見つかりません")
+
+        # ---- PDF ダウンロード ----
+        # B0020.aspx が PDF を返すが Chrome の PDF ビューア拡張が先にインターセプト
+        # するため response リスナーには HTML ラッパーが届く。
+        # context.route() で拡張処理前に PDF バイトを捕捉する。
+        pdf_link = year_row.get_by_role("link", name="PDF表示")
+        if pdf_link.count() > 0:
+            pdf_bytes_holder: list[bytes] = []
+
+            def _route_pdf(route, request) -> None:
+                # chrome-extension:// 等は fetch 不可なのでスキップ
+                if not request.url.startswith(("http://", "https://")):
+                    route.continue_()
+                    return
+                response = route.fetch()
+                ct = response.headers.get("content-type", "")
+                if "application/pdf" in ct and response.status == 200:
+                    try:
+                        # Content-Disposition からオリジナルファイル名を取得
+                        cd = response.headers.get("content-disposition", "")
+                        import re as _re
+                        m = _re.search(r'filename[^;=\n]*=([^;\n]*)', cd)
+                        fn = m.group(1).strip().strip('"\'') if m else ""
+                        if not fn:
+                            fn = request.url.rstrip("/").split("/")[-1].split("?")[0]
+                        if not fn.lower().endswith(".pdf"):
+                            fn = f"{fn}.pdf" if fn else f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_nentori.pdf"
+                        pdf_bytes_holder.append((fn, response.body()))
+                    except Exception as e:
+                        print(f"[{self.name}] PDF body取得失敗: {e}")
+                route.fulfill(response=response)
+
+            page.context.route("https://report.rakuten-sec.co.jp/**", _route_pdf)
+            try:
+                with page.expect_popup() as popup_info:
+                    pdf_link.click()
+                popup = popup_info.value
+                popup.wait_for_load_state("networkidle")
+                _wait()
+                popup.close()
+            finally:
+                page.context.unroute("https://report.rakuten-sec.co.jp/**", _route_pdf)
+
+            if pdf_bytes_holder:
+                pdf_filename, pdf_bytes = pdf_bytes_holder[0]
+                pdf_path = self.output_dir / pdf_filename
+                pdf_path.write_bytes(pdf_bytes)
+                downloaded.append(str(pdf_path))
+                print(f"[{self.name}] PDF 保存: {pdf_path}")
+            else:
+                print(f"[{self.name}] PDF レスポンスを捕捉できませんでした")
+            _wait()
+        else:
+            print(f"[{self.name}] {year}年の PDF表示リンクが見つかりません")
+
+        return downloaded
+
+    # ------------------------------------------------------------------
+    # JSON 変換
+    # ------------------------------------------------------------------
+    def _convert_to_json(self, downloaded_files: list[str]) -> None:
+        year = self.config["target_year"]
+        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
+        if not xml_files:
+            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
+            return
+
+        raw_files = [str(Path(f).name) for f in downloaded_files]
+        data = convert_teg204_xml(
+            xml_path=xml_files[0],
+            company=self.name,
+            code=self.code,
+            year=year,
+            raw_files=raw_files,
+        )
+
+        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        print(f"[{self.name}] JSON 保存: {json_path}")
+
+    # ------------------------------------------------------------------
+    # メイン収集フロー
+    # ------------------------------------------------------------------
+    def collect(self) -> None:
+        page = self.launch_browser()
+        try:
+            self._wait_for_login(page)
+            self._navigate_to_report_list(page)
+
+            year = self.config["target_year"]
+            if page.locator(f"tr:has(td span:text-is('{year}'))").count() == 0:
+                self.log_result("skip", [], f"{year}年の取引報告書が存在しません")
+                return
+
+            downloaded = self._download_files(page)
+
+            if not downloaded:
+                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+                return
+
+            self._convert_to_json(downloaded)
+            self.log_result("success", downloaded)
+
+        except KeyboardInterrupt:
+            print(f"\n[{self.name}] ユーザーによる中断")
+            self.log_result("interrupted", [], "ユーザーによる中断")
+        except Exception as e:
+            print(f"[{self.name}] エラー: {e}")
+            self.log_result("error", [], str(e))
+            raise
+        finally:
+            self.close_browser()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="楽天証券 年間取引報告書収集")
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=None,
+        help="対象年度（未指定時は site.json の target_year を使用）",
+    )
+    args = parser.parse_args()
+    collector = RakutenCollector(year=args.year)
+    collector.collect()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/money_ops/converter/xml_to_json.py
+++ b/src/money_ops/converter/xml_to_json.py
@@ -1,4 +1,13 @@
-"""TEG204 XML（e-Tax 特定口座年間取引報告書）→ nenkantorihikihokokusho.json 変換モジュール"""
+"""TEG204 XML（e-Tax 特定口座年間取引報告書）→ nenkantorihikihokokusho.json 変換モジュール
+
+e-Tax 標準フォーマット TEG204 の名前空間付き XML を解析する。
+ルート要素: {http://xml.e-tax.nta.go.jp/XSD/kyotsu}TEG204
+
+主要グループ:
+  ZLE00000 : 口座/顧客情報
+  ZLF00000 : 財務データ（譲渡・配当等・NISA・源泉徴収税額）
+  ZLG00000 / ZLH00000 : 証券会社情報（会社により異なる）
+"""
 
 from __future__ import annotations
 
@@ -6,27 +15,71 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from pathlib import Path
 
+_NS_K = "http://xml.e-tax.nta.go.jp/XSD/kyotsu"
+_NS_G = "http://xml.e-tax.nta.go.jp/XSD/general"
+_K = f"{{{_NS_K}}}"
+_G = f"{{{_NS_G}}}"
+
 _ACCOUNT_KIND_MAP = {
     "1": "源泉徴収あり特定口座",
     "2": "源泉徴収なし特定口座",
 }
 
-
-def _text(root: ET.Element, tag: str, default: str = "0") -> str:
-    el = root.find(tag)
-    return el.text.strip() if el is not None and el.text else default
+# 元号ベース年 (元号N年 = BASE + N)
+_ERA_BASE: dict[int, int] = {1: 1867, 2: 1911, 3: 1925, 4: 1988, 5: 2018}
 
 
-def _int(root: ET.Element, tag: str) -> int:
-    return int(_text(root, tag, "0"))
+# ---------------------------------------------------------------------------
+# 内部ヘルパー
+# ---------------------------------------------------------------------------
+
+def _find(root: ET.Element | None, *tags: str) -> ET.Element | None:
+    """NS_K 名前空間で path を順に辿って要素を返す。途中が None なら None。"""
+    el = root
+    for tag in tags:
+        if el is None:
+            return None
+        el = el.find(_K + tag)
+    return el
 
 
-def _date(yyyymmdd: str) -> str:
-    """YYYYMMDD → YYYY-MM-DD"""
-    if len(yyyymmdd) == 8:
-        return f"{yyyymmdd[:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:]}"
-    return yyyymmdd
+def _ktext(root: ET.Element | None, *tags: str, default: str = "0") -> str:
+    el = _find(root, *tags)
+    return el.text.strip() if el is not None and el.text and el.text.strip() else default
 
+
+def _kint(root: ET.Element | None, *tags: str) -> int:
+    return int(_ktext(root, *tags, default="0"))
+
+
+def _kubun(root: ET.Element | None, *tags: str) -> str | None:
+    """path を辿った末尾要素の子 kubun_CD のテキストを返す。"""
+    el = _find(root, *tags)
+    if el is None:
+        return None
+    kubun = el.find(_K + "kubun_CD")
+    return kubun.text.strip() if kubun is not None and kubun.text else None
+
+
+def _gdate(el: ET.Element | None) -> str:
+    """{NS_G}era / yy / mm / dd 子要素を持つ要素から YYYY-MM-DD 文字列を返す。"""
+    if el is None:
+        return ""
+    era = el.findtext(_G + "era")
+    yy = el.findtext(_G + "yy")
+    mm = el.findtext(_G + "mm")
+    dd = el.findtext(_G + "dd")
+    if not (era and yy):
+        return ""
+    year = _ERA_BASE.get(int(era), 0) + int(yy)
+    if mm and dd:
+        return f"{year:04d}-{int(mm):02d}-{int(dd):02d}"
+    return str(year)
+
+
+# ---------------------------------------------------------------------------
+# 公開 API
+# ---------------------------------------------------------------------------
 
 def convert_teg204_xml(
     xml_path: str | Path,
@@ -43,9 +96,9 @@ def convert_teg204_xml(
     xml_path:
         TEG204 XML ファイルのパス
     company:
-        証券会社名（registry.json の name）
+        証券会社名（site.json の name）
     code:
-        証券会社コード（registry.json の code）
+        証券会社コード（site.json の code）
     year:
         対象年度（例: 2025）
     raw_files:
@@ -56,10 +109,26 @@ def convert_teg204_xml(
     tree = ET.parse(xml_path)
     root = tree.getroot()
 
-    account_kind_code = _text(root, "ZLE010", "1")
+    # ---- 口座情報 (ZLE00000) ----
+    zle = root.find(_K + "ZLE00000")
+    account_kind_code = _kubun(zle, "ZLE00120") or "1"
     account_kind = _ACCOUNT_KIND_MAP.get(account_kind_code, account_kind_code)
-    kasetsu_raw = _text(root, "ZLE040", "")
-    kasetsu = _date(kasetsu_raw) if kasetsu_raw else ""
+    joto_gensen = _kubun(zle, "ZLE00070", "ZLE00080") == "1"
+    haitou_gensen = _kubun(zle, "ZLE00070", "ZLE00090") == "1"
+    kasetsu = _gdate(_find(zle, "ZLE00110"))
+
+    # ---- 財務データ (ZLF00000) ----
+    zlf = root.find(_K + "ZLF00000")
+    zlf010 = _find(zlf, "ZLF00010")   # 譲渡セクション
+    zlf190 = _find(zlf, "ZLF00190")   # 配当等セクション
+
+    def fi(*tags: str) -> int:
+        """ZLF00010 配下のパスから int を返す。"""
+        return _kint(zlf010, *tags) if zlf010 is not None else 0
+
+    def fd(*tags: str) -> int:
+        """ZLF00190 配下のパスから int を返す。"""
+        return _kint(zlf190, *tags) if zlf190 is not None else 0
 
     return {
         "company": company,
@@ -69,94 +138,78 @@ def convert_teg204_xml(
         "source": "xml",
         "account": {
             "口座種別": account_kind,
-            "譲渡所得源泉徴収": _int(root, "ZLE020") == 1,
-            "配当所得源泉徴収": _int(root, "ZLE030") == 1,
+            "譲渡所得源泉徴収": joto_gensen,
+            "配当所得源泉徴収": haitou_gensen,
             "開設日": kasetsu,
         },
         "譲渡": {
-            "取引件数_上場株式等": _int(root, "ZLH010"),
-            "取引件数_信用等": _int(root, "ZLH020"),
-            "取引件数_一般株式等": _int(root, "ZLH030"),
+            "取引件数_上場株式等": fi("ZLF00020"),
+            "取引件数_信用等": fi("ZLF00030"),
+            "取引件数_一般株式等": fi("ZLF00040"),
             "上場株式等": {
-                "譲渡の対価の額": _int(root, "ZLH040"),
-                "取得費及び譲渡に要した費用の額等": _int(root, "ZLH050"),
-                "差引金額_譲渡損益": _int(root, "ZLH060"),
+                "譲渡の対価の額": fi("ZLF00050", "ZLF00060"),
+                "取得費及び譲渡に要した費用の額等": fi("ZLF00050", "ZLF00080"),
+                "差引金額_譲渡損益": fi("ZLF00050", "ZLF00100"),
             },
             "一般株式等": {
-                "譲渡の対価の額": _int(root, "ZLH070"),
-                "取得費及び譲渡に要した費用の額等": _int(root, "ZLH080"),
-                "差引金額_譲渡損益": _int(root, "ZLH090"),
-            },
-            "損益通算後": {
-                "所得控除の額の合計額": _int(root, "ZLH100"),
-                "差引所得税額": _int(root, "ZLH110"),
-                "翌年繰越損失額": _int(root, "ZLH120"),
+                "譲渡の対価の額": fi("ZLF00110", "ZLF00120"),
+                "取得費及び譲渡に要した費用の額等": fi("ZLF00110", "ZLF00130"),
+                "差引金額_譲渡損益": fi("ZLF00110", "ZLF00140"),
             },
             "合計": {
-                "課税標準": _int(root, "ZLH130"),
-                "取得費等": _int(root, "ZLH140"),
-                "差引損益": _int(root, "ZLH150"),
+                "課税標準": fi("ZLF00150", "ZLF00160"),
+                "取得費等": fi("ZLF00150", "ZLF00170"),
+                "差引損益": fi("ZLF00150", "ZLF00180"),
             },
         },
         "配当等": {
             "上場株式の配当等": {
-                "配当等の額": _int(root, "ZLI010"),
-                "所得税": _int(root, "ZLI020"),
-                "復興特別所得税": _int(root, "ZLI030"),
-                "地方税": _int(root, "ZLI040"),
+                "配当等の額": fd("ZLF00200", "ZLF00210"),
+                "所得税": fd("ZLF00200", "ZLF00220"),
+                "復興特別所得税": fd("ZLF00200", "ZLF00230"),
+                "地方税": fd("ZLF00200", "ZLF00240"),
             },
             "特定株式投資信託の収益の分配等": {
-                "配当等の額": _int(root, "ZLI050"),
-                "所得税": _int(root, "ZLI060"),
-                "復興特別所得税": _int(root, "ZLI070"),
-                "地方税": _int(root, "ZLI080"),
+                "配当等の額": fd("ZLF00250", "ZLF00260"),
+                "所得税": fd("ZLF00250", "ZLF00270"),
+                "復興特別所得税": fd("ZLF00250", "ZLF00280"),
+                "地方税": fd("ZLF00250", "ZLF00290"),
             },
             "一般株式等の配当等": {
-                "配当等の額": _int(root, "ZLI090"),
-                "所得税": _int(root, "ZLI100"),
-                "復興特別所得税": _int(root, "ZLI110"),
-                "地方税": _int(root, "ZLI120"),
+                "配当等の額": fd("ZLF00300", "ZLF00310"),
+                "所得税": fd("ZLF00300", "ZLF00320"),
+                "復興特別所得税": fd("ZLF00300", "ZLF00330"),
+                "地方税": fd("ZLF00300", "ZLF00340"),
             },
             "投資信託等の収益の分配等": {
-                "配当等の額": _int(root, "ZLI130"),
-                "所得税": _int(root, "ZLI140"),
-                "復興特別所得税": _int(root, "ZLI150"),
-                "地方税": _int(root, "ZLI160"),
-            },
-            "非居住者等への配当等": {
-                "配当等の額": _int(root, "ZLI170"),
-                "所得税": _int(root, "ZLI180"),
-                "復興特別所得税": _int(root, "ZLI190"),
-                "地方税": _int(root, "ZLI200"),
+                "配当等の額": fd("ZLF00350", "ZLF00360"),
+                "所得税": fd("ZLF00350", "ZLF00370"),
+                "復興特別所得税": fd("ZLF00350", "ZLF00380"),
+                "地方税": fd("ZLF00350", "ZLF00390"),
             },
             "外国株式等の配当等": {
-                "配当等の額": _int(root, "ZLI210"),
-                "外国所得税": _int(root, "ZLI220"),
-            },
-            "NISA口座内の配当等": {
-                "配当等の額": _int(root, "ZLI230"),
+                "配当等の額": fd("ZLF00410", "ZLF00420"),
+                "所得税": fd("ZLF00410", "ZLF00430"),
+                "復興特別所得税": fd("ZLF00410", "ZLF00440"),
+                "外国所得税": fd("ZLF00410", "ZLF00450"),
             },
             "合計": {
-                "配当等の額": _int(root, "ZLI240"),
-                "所得税_源泉徴収税額": _int(root, "ZLI250"),
-                "復興特別所得税": _int(root, "ZLI260"),
-                "地方税": _int(root, "ZLI270"),
-                "納付税額": _int(root, "ZLI280"),
+                "配当等の額": fd("ZLF00460", "ZLF00470"),
+                "所得税_源泉徴収税額": fd("ZLF00460", "ZLF00480"),
+                "復興特別所得税": fd("ZLF00460", "ZLF00490"),
+                "地方税": fd("ZLF00460", "ZLF00500"),
+                "外国税": fd("ZLF00460", "ZLF00520"),
             },
         },
         "NISA": {
             "譲渡等": {
-                "譲渡の対価の額": _int(root, "ZLJ010"),
-                "取得費等": _int(root, "ZLJ020"),
+                "譲渡の対価の額": fd("ZLF00900", "ZLF00910"),
+                "取得費等": fd("ZLF00900", "ZLF00920"),
             },
         },
         "源泉徴収税額合計": {
-            "所得税": _int(root, "ZLK010"),
-            "復興特別所得税": _int(root, "ZLK020"),
-        },
-        "証券会社": {
-            "名称": _text(root, "ZLF010"),
-            "法人番号": _text(root, "ZLF020"),
+            "所得税": fd("ZLF00870", "ZLF00880"),
+            "復興特別所得税": fd("ZLF00870", "ZLF00890"),
         },
         "raw_files": raw_files or [],
         "collected_at": collected_at or datetime.now().isoformat(),

--- a/tests/fixtures/rakuten_elect_del_top.html
+++ b/tests/fixtures/rakuten_elect_del_top.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>取引報告書等（電子書面）</title>
+</head>
+<body>
+<table>
+  <thead>
+    <tr>
+      <th scope="col"><span>書類名</span></th>
+      <th scope="col"><span>年</span></th>
+      <th scope="col"><span>取引件数</span></th>
+      <th scope="col"><span>譲渡損益</span></th>
+      <th scope="col"><span>配当等</span></th>
+      <th scope="col"><span>源泉徴収税額</span></th>
+      <th scope="col"><span>本照合</span></th>
+      <th scope="col"><span>電子書面</span></th>
+      <th scope="col"><span>CSV/XML</span></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="1"><span>特定口座年間取引報告書</span></td>
+      <td rowspan="1"><span>2025</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td rowspan="1">
+        <span class="pcmm--is-clr-font-strong-id" id="196876353">本照合</span>
+      </td>
+      <td rowspan="1">
+        <a href="javascript:void(0);" onclick="browseRpt('196876353', '001','20251231','', '1', '', '1', '702', '518455', '01'); return false;" class="pcmm-btlk-link" target="_blank" rel="noopener">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-pdf-outline" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">PDF表示</span>
+        </a>
+      </td>
+      <td rowspan="1">
+        <button type="button" class="pcmm-btlk-link" onclick="dlXmlSpaYearyRpt('2025', '20251231', '702', '518455', '001'); return false;" data-ratId="mem_pc_denshishomen_nentori-xml" data-ratEvent="click" data-ratParam="all">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-download-filled" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">XML保存</span>
+        </button>
+      </td>
+    </tr>
+    <tr data-tr-group="even">
+      <td rowspan="1"><span>特定口座年間取引報告書</span></td>
+      <td rowspan="1"><span>2024</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td rowspan="1">
+        <span class="pcmm--is-clr-font-strong-id" id="165812116">本照合</span>
+      </td>
+      <td rowspan="1">
+        <a href="javascript:void(0);" onclick="browseRpt('165812116', '001','20241231','', '1', '', '1', '702', '518455', '01'); return false;" class="pcmm-btlk-link" target="_blank" rel="noopener">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-pdf-outline" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">PDF表示</span>
+        </a>
+      </td>
+      <td rowspan="1">
+        <button type="button" class="pcmm-btlk-link" onclick="dlXmlSpaYearyRpt('2024', '20241231', '702', '518455', '001'); return false;" data-ratId="mem_pc_denshishomen_nentori-xml" data-ratEvent="click" data-ratParam="all">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-download-filled" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">XML保存</span>
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="1"><span>特定口座年間取引報告書</span></td>
+      <td rowspan="1"><span>2023</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td><span>&ndash;</span></td>
+      <td rowspan="1">
+        <span class="pcmm--is-clr-font-strong-id" id="140000001">本照合</span>
+      </td>
+      <td rowspan="1">
+        <a href="javascript:void(0);" onclick="browseRpt('140000001', '001','20231231','', '1', '', '1', '702', '518455', '01'); return false;" class="pcmm-btlk-link" target="_blank" rel="noopener">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-pdf-outline" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">PDF表示</span>
+        </a>
+      </td>
+      <td rowspan="1">
+        <button type="button" class="pcmm-btlk-link" onclick="dlXmlSpaYearyRpt('2023', '20231231', '702', '518455', '001'); return false;" data-ratId="mem_pc_denshishomen_nentori-xml" data-ratEvent="click" data-ratParam="all">
+          <span class="pcmm-btlk__icon pcmm-ico rex-icon-download-filled" role="img" aria-hidden="true"></span>
+          <span class="pcmm-btlk__text">XML保存</span>
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/tests/fixtures/teg204_sample.xml
+++ b/tests/fixtures/teg204_sample.xml
@@ -1,93 +1,147 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   TEG204 特定口座年間取引報告書 サンプル（匿名化済み）
-  e-Tax 標準フォーマット BZL030010 準拠
+  e-Tax 標準フォーマット TEG204 準拠（名前空間付き）
 -->
-<BZL030010>
-  <!-- 支払いの取扱者（証券会社）情報 -->
-  <ZLF010>サンプル証券株式会社</ZLF010>
-  <ZLF020>1234567890123</ZLF020>
+<kyotsu:TEG204
+  xmlns:kyotsu="http://xml.e-tax.nta.go.jp/XSD/kyotsu"
+  xmlns:general="http://xml.e-tax.nta.go.jp/XSD/general"
+  VR="1.0" id="TEG204_SAMPLE_001" page="1"
+  sakuseiDay="2026-01-01" sakuseiNM="サンプル証券株式会社" softNM="sample-soft">
 
-  <!-- 口座情報 -->
-  <ZLE010>1</ZLE010>
-  <ZLE020>1</ZLE020>
-  <ZLE030>1</ZLE030>
-  <ZLE040>20100310</ZLE040>
+  <!-- 書類名 -->
+  <kyotsu:ZLA00000>特定口座年間取引報告書</kyotsu:ZLA00000>
 
-  <!-- 取引件数 -->
-  <ZLH010>10</ZLH010>
-  <ZLH020>5</ZLH020>
-  <ZLH030>0</ZLH030>
+  <!-- 年度: 令和7年 (2025) -->
+  <kyotsu:ZLB00000>
+    <general:era>5</general:era>
+    <general:yy>7</general:yy>
+  </kyotsu:ZLB00000>
 
-  <!-- 上場株式等の譲渡 -->
-  <ZLH040>1000000</ZLH040>
-  <ZLH050>900000</ZLH050>
-  <ZLH060>100000</ZLH060>
+  <!-- 口座/顧客情報 -->
+  <kyotsu:ZLE00000>
+    <!-- 源泉徴収区分 (ZLE00080=譲渡, ZLE00090=配当, ZLE00100=その他) -->
+    <kyotsu:ZLE00070>
+      <kyotsu:ZLE00080><kyotsu:kubun_CD>1</kyotsu:kubun_CD></kyotsu:ZLE00080>
+      <kyotsu:ZLE00090><kyotsu:kubun_CD>1</kyotsu:kubun_CD></kyotsu:ZLE00090>
+      <kyotsu:ZLE00100><kyotsu:kubun_CD>1</kyotsu:kubun_CD></kyotsu:ZLE00100>
+    </kyotsu:ZLE00070>
+    <!-- 口座開設日: 平成22年3月10日 = 2010-03-10 -->
+    <kyotsu:ZLE00110>
+      <general:era>4</general:era>
+      <general:yy>22</general:yy>
+      <general:mm>3</general:mm>
+      <general:dd>10</general:dd>
+    </kyotsu:ZLE00110>
+    <!-- 口座種別: 1=源泉徴収あり特定口座 -->
+    <kyotsu:ZLE00120><kyotsu:kubun_CD>1</kyotsu:kubun_CD></kyotsu:ZLE00120>
+  </kyotsu:ZLE00000>
 
-  <!-- 一般株式等の譲渡 -->
-  <ZLH070>0</ZLH070>
-  <ZLH080>0</ZLH080>
-  <ZLH090>0</ZLH090>
+  <!-- 財務データ -->
+  <kyotsu:ZLF00000>
 
-  <!-- 損益通算後 -->
-  <ZLH100>0</ZLH100>
-  <ZLH110>10000</ZLH110>
-  <ZLH120>0</ZLH120>
+    <!-- 譲渡セクション -->
+    <kyotsu:ZLF00010>
+      <!-- 取引件数 -->
+      <kyotsu:ZLF00020>10</kyotsu:ZLF00020>
+      <kyotsu:ZLF00030>5</kyotsu:ZLF00030>
+      <kyotsu:ZLF00040>0</kyotsu:ZLF00040>
 
-  <!-- 合計 -->
-  <ZLH130>1000000</ZLH130>
-  <ZLH140>900000</ZLH140>
-  <ZLH150>100000</ZLH150>
+      <!-- 上場株式等の譲渡 -->
+      <kyotsu:ZLF00050>
+        <kyotsu:ZLF00060>1000000</kyotsu:ZLF00060>
+        <kyotsu:ZLF00070>0</kyotsu:ZLF00070>
+        <kyotsu:ZLF00080>900000</kyotsu:ZLF00080>
+        <kyotsu:ZLF00090>0</kyotsu:ZLF00090>
+        <kyotsu:ZLF00100>100000</kyotsu:ZLF00100>
+      </kyotsu:ZLF00050>
 
-  <!-- 上場株式の配当等 -->
-  <ZLI010>50000</ZLI010>
-  <ZLI020>7655</ZLI020>
-  <ZLI030>2499</ZLI030>
-  <ZLI040>0</ZLI040>
+      <!-- 一般株式等の譲渡 -->
+      <kyotsu:ZLF00110>
+        <kyotsu:ZLF00120>0</kyotsu:ZLF00120>
+        <kyotsu:ZLF00130>0</kyotsu:ZLF00130>
+        <kyotsu:ZLF00140>0</kyotsu:ZLF00140>
+      </kyotsu:ZLF00110>
 
-  <!-- 特定株式投資信託の収益の分配等 -->
-  <ZLI050>20000</ZLI050>
-  <ZLI060>3064</ZLI060>
-  <ZLI070>998</ZLI070>
-  <ZLI080>0</ZLI080>
+      <!-- 合計 -->
+      <kyotsu:ZLF00150>
+        <kyotsu:ZLF00160>1000000</kyotsu:ZLF00160>
+        <kyotsu:ZLF00170>900000</kyotsu:ZLF00170>
+        <kyotsu:ZLF00180>100000</kyotsu:ZLF00180>
+      </kyotsu:ZLF00150>
+    </kyotsu:ZLF00010>
 
-  <!-- 一般株式等の配当等 -->
-  <ZLI090>100</ZLI090>
-  <ZLI100>11</ZLI100>
-  <ZLI110>3</ZLI110>
-  <ZLI120>10</ZLI120>
+    <!-- 配当等セクション -->
+    <kyotsu:ZLF00190>
 
-  <!-- 投資信託等の収益の分配等 -->
-  <ZLI130>200000</ZLI130>
-  <ZLI140>30630</ZLI140>
-  <ZLI150>9990</ZLI150>
-  <ZLI160>20000</ZLI160>
+      <!-- 上場株式の配当等 -->
+      <kyotsu:ZLF00200>
+        <kyotsu:ZLF00210>50000</kyotsu:ZLF00210>
+        <kyotsu:ZLF00220>7655</kyotsu:ZLF00220>
+        <kyotsu:ZLF00230>2499</kyotsu:ZLF00230>
+        <kyotsu:ZLF00240>0</kyotsu:ZLF00240>
+        <kyotsu:ZLF00245>0</kyotsu:ZLF00245>
+      </kyotsu:ZLF00200>
 
-  <!-- 非居住者等への配当等 -->
-  <ZLI170>0</ZLI170>
-  <ZLI180>0</ZLI180>
-  <ZLI190>0</ZLI190>
-  <ZLI200>0</ZLI200>
+      <!-- 特定株式投資信託の収益の分配等 -->
+      <kyotsu:ZLF00250>
+        <kyotsu:ZLF00260>20000</kyotsu:ZLF00260>
+        <kyotsu:ZLF00270>3064</kyotsu:ZLF00270>
+        <kyotsu:ZLF00280>998</kyotsu:ZLF00280>
+        <kyotsu:ZLF00290>0</kyotsu:ZLF00290>
+        <kyotsu:ZLF00295>0</kyotsu:ZLF00295>
+      </kyotsu:ZLF00250>
 
-  <!-- 外国株式等の配当等 -->
-  <ZLI210>0</ZLI210>
-  <ZLI220>0</ZLI220>
+      <!-- 一般株式等の配当等 -->
+      <kyotsu:ZLF00300>
+        <kyotsu:ZLF00310>0</kyotsu:ZLF00310>
+        <kyotsu:ZLF00320>0</kyotsu:ZLF00320>
+        <kyotsu:ZLF00330>0</kyotsu:ZLF00330>
+        <kyotsu:ZLF00340>0</kyotsu:ZLF00340>
+        <kyotsu:ZLF00345>0</kyotsu:ZLF00345>
+      </kyotsu:ZLF00300>
 
-  <!-- NISA口座内の配当等 -->
-  <ZLI230>0</ZLI230>
+      <!-- 投資信託等の収益の分配等 -->
+      <kyotsu:ZLF00350>
+        <kyotsu:ZLF00360>0</kyotsu:ZLF00360>
+        <kyotsu:ZLF00370>0</kyotsu:ZLF00370>
+        <kyotsu:ZLF00380>0</kyotsu:ZLF00380>
+        <kyotsu:ZLF00390>0</kyotsu:ZLF00390>
+        <kyotsu:ZLF00400>0</kyotsu:ZLF00400>
+        <kyotsu:ZLF00405>0</kyotsu:ZLF00405>
+      </kyotsu:ZLF00350>
 
-  <!-- 配当等の合計 -->
-  <ZLI240>270100</ZLI240>
-  <ZLI250>41360</ZLI250>
-  <ZLI260>13490</ZLI260>
-  <ZLI270>20010</ZLI270>
-  <ZLI280>20010</ZLI280>
+      <!-- 外国株式等の配当等 -->
+      <kyotsu:ZLF00410>
+        <kyotsu:ZLF00420>0</kyotsu:ZLF00420>
+        <kyotsu:ZLF00430>0</kyotsu:ZLF00430>
+        <kyotsu:ZLF00440>0</kyotsu:ZLF00440>
+        <kyotsu:ZLF00450>0</kyotsu:ZLF00450>
+      </kyotsu:ZLF00410>
 
-  <!-- 源泉徴収税額合計 -->
-  <ZLK010>41360</ZLK010>
-  <ZLK020>13490</ZLK020>
+      <!-- 配当等合計 -->
+      <kyotsu:ZLF00460>
+        <kyotsu:ZLF00470>70000</kyotsu:ZLF00470>
+        <kyotsu:ZLF00480>10719</kyotsu:ZLF00480>
+        <kyotsu:ZLF00490>3497</kyotsu:ZLF00490>
+        <kyotsu:ZLF00500>0</kyotsu:ZLF00500>
+        <kyotsu:ZLF00515>0</kyotsu:ZLF00515>
+        <kyotsu:ZLF00520>0</kyotsu:ZLF00520>
+      </kyotsu:ZLF00460>
 
-  <!-- NISA口座内の上場株式等の譲渡 -->
-  <ZLJ010>0</ZLJ010>
-  <ZLJ020>0</ZLJ020>
-</BZL030010>
+      <!-- 源泉徴収税額合計 (譲渡分+配当分) -->
+      <kyotsu:ZLF00870>
+        <kyotsu:ZLF00880>18374</kyotsu:ZLF00880>
+        <kyotsu:ZLF00890>5996</kyotsu:ZLF00890>
+      </kyotsu:ZLF00870>
+
+      <!-- NISA口座内譲渡等 -->
+      <kyotsu:ZLF00900>
+        <kyotsu:ZLF00910>0</kyotsu:ZLF00910>
+        <kyotsu:ZLF00920>0</kyotsu:ZLF00920>
+      </kyotsu:ZLF00900>
+
+    </kyotsu:ZLF00190>
+  </kyotsu:ZLF00000>
+
+</kyotsu:TEG204>

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -1,0 +1,277 @@
+"""楽天証券収集スクリプトのユニットテスト（Playwright モック）"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+_SITE_JSON = _PROJECT_ROOT / "skills" / "tax-collect" / "sites" / "rakuten" / "site.json"
+
+import importlib.util
+
+_COLLECT_PY = _PROJECT_ROOT / "skills" / "tax-collect" / "sites" / "rakuten" / "collect.py"
+_spec = importlib.util.spec_from_file_location("rakuten_collect", _COLLECT_PY)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+RakutenCollector = _mod.RakutenCollector
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_collector(tmp_path: Path, year: int = 2025) -> RakutenCollector:
+    config = json.loads(_SITE_JSON.read_text(encoding="utf-8"))
+    config["output_dir"] = str(tmp_path / "raw")
+    config["target_year"] = year
+    tmp_site = tmp_path / "site.json"
+    tmp_site.write_text(json.dumps(config), encoding="utf-8")
+    # year=None で渡して config の値を使わせる（output_dir 上書きを防ぐ）
+    return RakutenCollector(site_json_path=tmp_site)
+
+
+# ---------------------------------------------------------------------------
+# 初期化テスト
+# ---------------------------------------------------------------------------
+
+def test_init_default_year(tmp_path):
+    collector = _make_collector(tmp_path)
+    assert collector.config["target_year"] == 2025
+    assert collector.code == "rakuten"
+    assert collector.name == "楽天証券"
+
+
+def test_init_override_year(tmp_path):
+    collector = _make_collector(tmp_path, year=2024)
+    assert collector.config["target_year"] == 2024
+    assert collector.output_dir == tmp_path / "raw"
+
+
+# ---------------------------------------------------------------------------
+# 手動ログイン待機テスト
+# ---------------------------------------------------------------------------
+
+def test_wait_for_login(tmp_path):
+    collector = _make_collector(tmp_path)
+    page = MagicMock()
+
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        collector._wait_for_login(page)
+
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+# ---------------------------------------------------------------------------
+# ナビゲーションテスト
+# ---------------------------------------------------------------------------
+
+def test_navigate_to_report_list(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+
+    calls = []
+
+    def get_by_role_side(role, **kwargs):
+        calls.append((role, kwargs.get("name", "")))
+        return MagicMock()
+
+    page.get_by_role.side_effect = get_by_role_side
+
+    with patch.object(_mod, "_wait"):
+        collector._navigate_to_report_list(page)
+
+    names = [name for _, name in calls]
+    assert "マイメニュー 口座管理・入出金など" in names
+    assert "確定申告サポート" in names
+    assert "2025年" in names
+    assert "取引報告書等(電子書面)" in names
+
+
+# ---------------------------------------------------------------------------
+# ダウンロードテスト
+# ---------------------------------------------------------------------------
+
+def _make_download_mock(saved_paths: list, content: bytes = b"dummy"):
+    dl = MagicMock()
+
+    def save_as(path):
+        saved_paths.append(path)
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(content)
+
+    dl.value.save_as = save_as
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=dl)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def test_download_files_xml_and_pdf(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    saved: list[str] = []
+
+    page = MagicMock()
+    context = MagicMock()
+    page.context = context
+
+    # 年度行あり
+    year_row = MagicMock()
+    year_row.count.return_value = 1
+
+    xml_button = MagicMock()
+    xml_button.count.return_value = 1
+    pdf_link = MagicMock()
+    pdf_link.count.return_value = 1
+
+    def get_by_role_side(role, **kwargs):
+        name = kwargs.get("name", "")
+        if "XML" in name:
+            return xml_button
+        return pdf_link
+
+    year_row.get_by_role.side_effect = get_by_role_side
+    page.locator.return_value = year_row
+
+    # XML ダウンロード: suggested_filename を返す
+    dl_mock = MagicMock()
+    dl_mock.suggested_filename = "1234-Z00-00000000001.xml"
+
+    def save_as_side(path):
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(b"<xml/>")
+        saved.append(path)
+
+    dl_mock.save_as.side_effect = save_as_side
+    dl_cm = MagicMock()
+    dl_cm.__enter__ = MagicMock(return_value=MagicMock(value=dl_mock))
+    dl_cm.__exit__ = MagicMock(return_value=False)
+    page.expect_download.return_value = dl_cm
+
+    # PDF ポップアップ
+    popup = MagicMock()
+    popup_cm = MagicMock()
+    popup_cm.__enter__ = MagicMock(return_value=MagicMock(value=popup))
+    popup_cm.__exit__ = MagicMock(return_value=False)
+    page.expect_popup.return_value = popup_cm
+
+    # route ハンドラが呼ばれたとき PDF を注入
+    def context_route_side(pattern, handler):
+        # ハンドラを即時呼び出してPDFバイトを注入
+        route = MagicMock()
+        response = MagicMock()
+        response.headers = {"content-type": "application/pdf"}
+        response.status = 200
+        response.body.return_value = b"%PDF-dummy"
+        route.fetch.return_value = response
+        request = MagicMock()
+        request.url = "https://report.rakuten-sec.co.jp/web/index.aspx"
+        handler(route, request)
+
+    context.route.side_effect = context_route_side
+
+    with patch.object(_mod, "_wait"):
+        result = collector._download_files(page)
+
+    # XML は保存される
+    assert any(".xml" in p for p in saved)
+    # PDF は保存される
+    assert any(".pdf" in p for p in result)
+
+
+def test_download_files_year_row_not_found(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+    page.locator.return_value.count.return_value = 0
+
+    with patch.object(_mod, "_wait"):
+        result = collector._download_files(page)
+
+    assert result == []
+
+
+def test_download_files_no_xml_button(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+
+    year_row = MagicMock()
+    year_row.count.return_value = 1
+    page.locator.return_value = year_row
+
+    xml_button = MagicMock()
+    xml_button.count.return_value = 0
+    pdf_link = MagicMock()
+    pdf_link.count.return_value = 0
+
+    def get_by_role_side(role, **kwargs):
+        name = kwargs.get("name", "")
+        if "XML" in name:
+            return xml_button
+        return pdf_link
+
+    year_row.get_by_role.side_effect = get_by_role_side
+
+    with patch.object(_mod, "_wait"):
+        result = collector._download_files(page)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# JSON 変換テスト
+# ---------------------------------------------------------------------------
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    collector = _make_collector(tmp_path)
+    collector._convert_to_json(["data/foo.pdf"])
+    captured = capsys.readouterr()
+    assert "スキップ" in captured.out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    fixture_xml = _PROJECT_ROOT / "tests" / "fixtures" / "teg204_sample.xml"
+    if not fixture_xml.exists():
+        pytest.skip("teg204_sample.xml が存在しません")
+
+    collector = _make_collector(tmp_path)
+    collector.output_dir.mkdir(parents=True, exist_ok=True)
+    collector._convert_to_json([str(fixture_xml)])
+
+    json_path = collector.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == "rakuten"
+    assert data["source"] == "xml"
+
+
+# ---------------------------------------------------------------------------
+# collect() スキップフロー
+# ---------------------------------------------------------------------------
+
+def test_collect_skip_when_year_row_not_found(tmp_path):
+    collector = _make_collector(tmp_path, year=2025)
+    page = MagicMock()
+
+    def locator_side_effect(selector):
+        m = MagicMock()
+        m.count.return_value = 0
+        m.filter.return_value.count.return_value = 0
+        return m
+
+    page.locator.side_effect = locator_side_effect
+
+    with patch.object(collector, "launch_browser", return_value=page), \
+         patch.object(collector, "close_browser"), \
+         patch.object(collector, "_wait_for_login"), \
+         patch.object(collector, "_navigate_to_report_list"), \
+         patch.object(collector, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        collector.collect()
+
+    mock_log.assert_called_once_with("skip", [], f"{collector.config['target_year']}年の取引報告書が存在しません")

--- a/tests/test_rakuten_selectors.py
+++ b/tests/test_rakuten_selectors.py
@@ -1,0 +1,112 @@
+"""楽天証券 電子書面ページのセレクタ検証テスト（実際のDOM構造を使用）
+
+fixtures/rakuten_elect_del_top.html を Playwright でロードし、
+collect.py が使うセレクタが実際に動作することを確認する。
+
+実機確認済み情報（2026-04-11）:
+- 電子書面一覧: https://member.rakuten-sec.co.jp/app/acc_elect_del_top.do
+- PDF ポップアップ: https://report.rakuten-sec.co.jp/web/B0020.aspx
+- PDF 本体レスポンス: https://report.rakuten-sec.co.jp/web/index.aspx (application/pdf)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_HTML = Path(__file__).parent / "fixtures" / "rakuten_elect_del_top.html"
+
+
+@pytest.fixture(scope="module")
+def page():
+    """Playwright ページを返す fixture"""
+    from playwright.sync_api import sync_playwright
+
+    pw = sync_playwright().start()
+    browser = pw.chromium.launch(headless=True)
+    p = browser.new_page()
+    yield p
+    browser.close()
+    pw.stop()
+
+
+def _load(page):
+    page.goto(_FIXTURE_HTML.as_uri())
+
+
+# ---------------------------------------------------------------------------
+# 年度行の特定
+# ---------------------------------------------------------------------------
+
+def test_year_row_2025_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('2025'))")
+    assert rows.count() == 1
+
+
+def test_year_row_2024_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('2024'))")
+    assert rows.count() == 1
+
+
+def test_year_row_2023_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('2023'))")
+    assert rows.count() == 1
+
+
+def test_year_row_9999_not_found(page):
+    _load(page)
+    rows = page.locator("tr:has(td span:text-is('9999'))")
+    assert rows.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 2025年行の XML保存・PDF表示ボタン
+# ---------------------------------------------------------------------------
+
+def test_2025_xml_button_found(page):
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2025'))")
+    xml_btn = year_row.get_by_role("button", name="XML保存")
+    assert xml_btn.count() == 1
+
+
+def test_2025_pdf_link_found(page):
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2025'))")
+    pdf_link = year_row.get_by_role("link", name="PDF表示")
+    assert pdf_link.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 年度をまたいで誤クリックしないことの確認
+# ---------------------------------------------------------------------------
+
+def test_2025_xml_button_not_2024(page):
+    """2025年行のXML保存ボタンが2024年のものでないことを確認"""
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2025'))")
+    xml_btn = year_row.get_by_role("button", name="XML保存")
+    onclick = xml_btn.get_attribute("onclick")
+    assert "'2025'" in onclick
+    assert "'2024'" not in onclick
+
+
+def test_2024_xml_button_not_2025(page):
+    _load(page)
+    year_row = page.locator("tr:has(td span:text-is('2024'))")
+    xml_btn = year_row.get_by_role("button", name="XML保存")
+    onclick = xml_btn.get_attribute("onclick")
+    assert "'2024'" in onclick
+    assert "'2025'" not in onclick
+
+
+def test_first_xml_button_is_not_reliable(page):
+    """ページ全体の最初のXML保存が必ずしも対象年度とは限らないことを確認"""
+    _load(page)
+    all_xml = page.get_by_role("button", name="XML保存")
+    assert all_xml.count() == 3  # 2025, 2024, 2023 の3行ある
+    # .first は 2025年だが、年度が変われば壊れる → 年度特定が必要

--- a/tests/test_xml_to_json.py
+++ b/tests/test_xml_to_json.py
@@ -6,6 +6,8 @@ from money_ops.converter import convert_teg204_xml
 
 SAMPLE_XML = Path(__file__).parent / "fixtures" / "teg204_sample.xml"
 
+_NS_K = "http://xml.e-tax.nta.go.jp/XSD/kyotsu"
+
 
 @pytest.fixture
 def result():
@@ -49,11 +51,11 @@ def test_譲渡_上場株式等(result):
     assert joto["差引金額_譲渡損益"] == 100000
 
 
-def test_譲渡_損益通算後(result):
-    tsu = result["譲渡"]["損益通算後"]
-    assert tsu["所得控除の額の合計額"] == 0
-    assert tsu["差引所得税額"] == 10000
-    assert tsu["翌年繰越損失額"] == 0
+def test_譲渡_合計(result):
+    total = result["譲渡"]["合計"]
+    assert total["課税標準"] == 1000000
+    assert total["取得費等"] == 900000
+    assert total["差引損益"] == 100000
 
 
 def test_配当等_上場株式(result):
@@ -64,13 +66,20 @@ def test_配当等_上場株式(result):
     assert div["地方税"] == 0
 
 
+def test_配当等_特定株式投信(result):
+    div = result["配当等"]["特定株式投資信託の収益の分配等"]
+    assert div["配当等の額"] == 20000
+    assert div["所得税"] == 3064
+    assert div["復興特別所得税"] == 998
+
+
 def test_配当等_合計(result):
     total = result["配当等"]["合計"]
-    assert total["配当等の額"] == 270100
-    assert total["所得税_源泉徴収税額"] == 41360
-    assert total["復興特別所得税"] == 13490
-    assert total["地方税"] == 20010
-    assert total["納付税額"] == 20010
+    assert total["配当等の額"] == 70000
+    assert total["所得税_源泉徴収税額"] == 10719
+    assert total["復興特別所得税"] == 3497
+    assert total["地方税"] == 0
+    assert total["外国税"] == 0
 
 
 def test_nisa(result):
@@ -81,14 +90,8 @@ def test_nisa(result):
 
 def test_源泉徴収税額合計(result):
     tax = result["源泉徴収税額合計"]
-    assert tax["所得税"] == 41360
-    assert tax["復興特別所得税"] == 13490
-
-
-def test_証券会社(result):
-    co = result["証券会社"]
-    assert co["名称"] == "サンプル証券株式会社"
-    assert co["法人番号"] == "1234567890123"
+    assert tax["所得税"] == 18374
+    assert tax["復興特別所得税"] == 5996
 
 
 def test_raw_files(result):
@@ -100,17 +103,18 @@ def test_collected_at(result):
 
 
 def test_missing_elements_default_zero(tmp_path):
-    """必須でない要素が欠けていても 0 にフォールバックする"""
+    """必須でない要素が欠けていても 0 にフォールバックする（最小 TEG204 XML）"""
     minimal_xml = tmp_path / "minimal.xml"
     minimal_xml.write_text(
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        "<BZL030010>"
-        "<ZLF010>テスト証券</ZLF010>"
-        "<ZLE010>2</ZLE010>"
-        "</BZL030010>",
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<TEG204 xmlns="{_NS_K}" VR="1.0" id="TEST" page="1"'
+        f' sakuseiDay="2026-01-01" sakuseiNM="test" softNM="test">'
+        f"</TEG204>",
         encoding="utf-8",
     )
-    result = convert_teg204_xml(minimal_xml, company="テスト証券", code="test", year=2025)
-    assert result["account"]["口座種別"] == "源泉徴収なし特定口座"
-    assert result["譲渡"]["取引件数_上場株式等"] == 0
-    assert result["配当等"]["合計"]["配当等の額"] == 0
+    r = convert_teg204_xml(minimal_xml, company="テスト証券", code="test", year=2025)
+    assert r["account"]["口座種別"] == "源泉徴収あり特定口座"
+    assert r["account"]["譲渡所得源泉徴収"] is False
+    assert r["譲渡"]["取引件数_上場株式等"] == 0
+    assert r["配当等"]["合計"]["配当等の額"] == 0
+    assert r["源泉徴収税額合計"]["所得税"] == 0


### PR DESCRIPTION
## Summary

- e-Tax TEG204 フォーマットの実際の XML 構造に合わせてコンバーターを全面改修
- `{http://xml.e-tax.nta.go.jp/XSD/kyotsu}` 名前空間への対応
- フラット3桁タグ（`ZLE010` 等）→ 実際の5桁ネスト構造（`ZLF00010/ZLF00020` 等）
- 元号 era/yy/mm/dd → 西暦変換・kubun_CD によるフラグ取得を実装
- fixture と test を新フォーマットに合わせて全面更新（47 tests all pass）

## 変更ファイル

- `src/money_ops/converter/xml_to_json.py` — 全面改修
- `tests/fixtures/teg204_sample.xml` — BZL030010 → TEG204 名前空間フォーマットへ更新
- `tests/test_xml_to_json.py` — 新スキーマに合わせてテスト更新
- `plan/20260411_1302_tax-collect.md` — #6 bugfix・#8 PR番号更新

## Test plan

- [x] `pytest tests/test_xml_to_json.py` — 13 passed
- [x] `pytest tests/` (全体) — 47 passed
- [x] 実際の楽天証券 XML で手動確認（取引件数・譲渡損益・配当等が正しく取得できることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)