### PR TITLE
chore: .venv-win/ を .gitignore の Python セクションに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 *.pyd
 .Python
 .venv/
+.venv-win/
 venv/
 env/
 *.egg-info/


### PR DESCRIPTION
## Summary
- Windows仮想環境ディレクトリ `.venv-win/` を `.gitignore` の Python セクション（`.venv/` の直下）に追加
- issue #17 のフォローアップ

## Test plan
- [ ] `.venv-win/` ディレクトリが git に追跡されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)