### PR TITLE
feat: #25 ウィブル証券 uiautomator2 Android自動収集スクリプト実装

### DIFF
--- a/.workbench/alias_rules
+++ b/.workbench/alias_rules
@@ -6,6 +6,7 @@
 #              $PROJECT_ROOT : プロジェクトルートパス
 # - DESCRIPTION: help / show-workspace-menu に表示される説明文
 
+adb           C:\Users\g\AppData\Local\Microsoft\WinGet\Packages\Google.PlatformTools_Microsoft.Winget.Source_8wekyb3d8bbwe\platform-tools\adb.exe @args  # Android Debug Bridge
 format        $VENV_PYTHON -m black . ; $VENV_PYTHON -m isort .  # black で整形 → isort で import 整理
 lint          $VENV_PYTHON -m mypy . ; $VENV_PYTHON -m pylint --recursive=y .  # 型チェック → 静的解析
 test          $VENV_PYTHON -m pytest @args  # pytest 実行

--- a/README_ADB.md
+++ b/README_ADB.md
@@ -1,0 +1,177 @@
+# Android ADB 接続セットアップ手順
+
+動作確認環境: Windows 10 / OPPO Reno 10 (Android 13) / 2026-04-23
+
+**USB 接続推奨**: ワイヤレスは接続が頻繁に切断される（ポートも毎回変わる）。スクリプト実行には USB 接続が安定。
+
+---
+
+## 1. ADB インストール（Windows）
+
+```powershell
+winget install Google.PlatformTools
+```
+
+> **注意**: インストール後、`adb` コマンドが認識されない場合がある。
+> winget の portable インストールは PATH が通らないことがある。
+
+### PATH が通っていない場合
+
+実際の adb.exe の場所を探す:
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Recurse -Filter "adb.exe" | Select-Object FullName
+```
+
+見つかったパスを `.workbench/alias_rules` に追加:
+
+```
+adb  C:\Users\<ユーザー名>\AppData\Local\Microsoft\WinGet\Packages\Google.PlatformTools_Microsoft.Winget.Source_8wekyb3d8bbwe\platform-tools\adb.exe @args
+```
+
+または永続的に PATH に追加:
+
+```powershell
+$adbDir = "C:\Users\g\AppData\Local\Microsoft\WinGet\Packages\Google.PlatformTools_Microsoft.Winget.Source_8wekyb3d8bbwe\platform-tools"
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$adbDir", "User")
+```
+
+インストール確認:
+
+```powershell
+adb version
+# Android Debug Bridge version 1.0.41 が出ればOK
+```
+
+---
+
+## 2. USB 接続（推奨）
+
+ワイヤレスより安定。ケーブル1本でポート固定・切断なし。
+
+### Android 側の設定
+
+1. 開発者向けオプションを有効化（→ 下記参照）
+2. 設定 → その他の設定 → 開発者向けオプション → **USB デバッグ** → ON
+
+### PC に接続
+
+1. USB ケーブルで接続
+2. Android に「USB デバッグを許可しますか？」→ **許可**（「このPCを常に許可」推奨）
+
+```powershell
+adb devices
+# 3d34b41d  device  ← シリアルが出れば完了
+```
+
+> シリアルは固定。以降は再接続不要（ケーブルを抜き差ししない限り）。
+
+---
+
+## 3. Android 側の設定（共通）
+
+### 開発者向けオプションを有効化
+
+OPPO Reno 10 の場合:
+
+1. 設定 → 端末情報
+2. **ビルド番号を7回タップ** → 「開発者向けオプションが有効になりました」
+
+---
+
+## 4. ワイヤレス接続（サブ）
+
+ワイヤレスを使う場合のみ。
+
+### ワイヤレスデバッグを有効化
+
+1. 設定 → その他の設定 → 開発者向けオプション
+2. **ワイヤレスデバッグ** → ON（トグル）
+3. 「ワイヤレスデバッグ」の**文字部分をタップ**（トグルではなく）して詳細画面へ
+
+---
+
+## 5. ペアリング（ワイヤレス・初回のみ）
+
+### Android 側
+
+「ワイヤレスデバッグ」詳細画面 → **「デバイスのペアリング（ペアリングコードを使用）」** をタップ
+
+→ IPアドレス・ポート番号・6桁コードが表示される
+
+> **注意**: コードの有効期限は短い（数十秒程度）。表示されたらすぐに PC 側で実行する。
+
+### PC 側
+
+```powershell
+adb pair <AndroidのIP>:<ペアリング画面のポート番号>
+# Enter pairing code: と聞かれたら6桁コードを入力
+# Successfully paired to ... が出ればOK
+```
+
+> **ハマりポイント**:
+> - ポート番号はペアリング画面に表示されるもの（例: `43387`）を使う
+> - コードが切れたら Android 側で再タップして新しいコード/ポートを取得
+> - `error: protocol fault` が出たらコード期限切れ → 再取得
+
+---
+
+## 6. ワイヤレス接続
+
+ペアリング成功後、接続に使うポートは**ワイヤレスデバッグのメイン画面**に表示される「IPアドレスとポート」。
+
+> ペアリングのポートと接続のポートは**別物**。
+
+```powershell
+adb connect <AndroidのIP>:<メイン画面のポート番号>
+# connected to 192.168.x.x:xxxxx が出ればOK
+
+adb devices
+# 192.168.x.x:xxxxx  device が出れば接続完了
+```
+
+---
+
+## 7. ワイヤレス再接続（2回目以降）
+
+ペアリングは不要。接続だけ実行:
+
+```powershell
+adb connect 192.168.2.196:39513
+adb devices
+```
+
+> **注意**: Android を再起動するとポート番号が変わる場合がある。
+> ワイヤレスデバッグ画面で現在のポートを確認してから接続。
+
+---
+
+## 8. mitmproxy と併用する場合の注意
+
+Android の Wi-Fi プロキシを mitmproxy に向けている間は:
+
+- ADB の接続が切れる場合がある（プロキシ経由でネットワークが不安定になる）
+- ウィブル等のピンニングしているアプリの通信はブロックされる
+
+**mitmproxy 使用後は必ずプロキシを「なし」に戻す**:
+
+設定 → Wi-Fi → 接続中のSSID → プロキシ → **なし**
+
+プロキシを無効にすると ADB 接続が切れるため、再接続が必要:
+
+```powershell
+adb connect 192.168.2.196:39513
+```
+
+---
+
+## 動作確認
+
+接続後、以下で画面の UI 構造を取得できる:
+
+```powershell
+adb shell uiautomator dump
+adb pull /sdcard/window_dump.xml
+```
+
+`window_dump.xml` に現在の画面の要素一覧が出力される。

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,9 @@ docling
 
 # GPU (CUDA) 使用時: CPU版 torch を上書き（Blackwell GPU は cu128 以上が必要）
 # pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu128
+
+# スマホプロキシ Wifiプロキシで設定して仲介するが、証明書ピンニングで無視されて直接通信になる
+#mitmproxy
+
+# Androidデバッグ操作
+uiautomator2

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -1,0 +1,283 @@
+"""ウィブル証券 特定口座年間取引報告書 uiautomator2 収集スクリプト
+
+使い方:
+    python collect.py [--year YYYY]
+
+前提:
+    - ADB でデバイスが接続済み（adb devices で確認）
+    - ウィブルアプリがログイン済み
+    - uiautomator2 インストール済み: pip install uiautomator2
+
+収集フロー:
+    1. アプリ起動
+    2. 取引画面 → 履歴タブ
+    3. 「特定口座年間取引報告書」（対象年）の行をタップ → WebView で PDF 表示
+    4. r2_menu_icon タップ → /sdcard/Documents/ に PDF 保存
+    5. adb pull でローカルへ転送
+
+UI 構造（uiautomator dump 確認済み）:
+    帳票タブ（TabTitle="帳票"）に最近の書類のみ表示。
+    履歴タブ（TabTitle="履歴"）に全書類が時系列で表示される。
+    各行: tv_name（書類名）+ tv_date（日付。年間報告書は "2025" のみ）
+    行タップ → WebView（resource-id=webview）で PDF 表示。
+    r2_menu_icon タップ → /sdcard/Documents/{date}.pdf に保存。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+from money_ops.converter.pdf_to_json import convert_pdf_to_json
+
+_SITE_JSON = Path(__file__).parent / "site.json"
+_PACKAGE = "org.dayup.stocks.jp"
+_DOCS_DIR = "/sdcard/Documents"
+_TARGET_DOC = "特定口座年間取引報告書"
+
+_ADB_FALLBACK = Path(
+    r"C:\Users\g\AppData\Local\Microsoft\WinGet\Packages"
+    r"\Google.PlatformTools_Microsoft.Winget.Source_8wekyb3d8bbwe"
+    r"\platform-tools\adb.exe"
+)
+
+
+def _adb(*args: str) -> str:
+    cmd = ["adb", *args]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+        )
+    except FileNotFoundError:
+        if _ADB_FALLBACK.exists():
+            cmd[0] = str(_ADB_FALLBACK)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+            )
+        else:
+            raise RuntimeError("adb が見つかりません。PATH に追加してください（README_ADB.md 参照）")
+    return result.stdout.strip()
+
+
+def _wait(t: float = 1.5) -> None:
+    time.sleep(t)
+
+
+class WebullCollector:
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
+        with open(site_json_path, encoding="utf-8") as f:
+            self.config = json.load(f)
+        self.name: str = self.config["name"]
+        self.code: str = self.config["code"]
+        if year is not None:
+            self.config["target_year"] = year
+            self.config["output_dir"] = f"data/income/securities/webull/{year}/raw/"
+        self.output_dir = _PROJECT_ROOT / self.config["output_dir"]
+
+    def _list_dir(self, remote_dir: str) -> set[str]:
+        out = _adb("shell", "ls", remote_dir)
+        return {f"{remote_dir}/{f.strip()}" for f in out.splitlines() if f.strip()}
+
+    def _snapshot(self) -> set[str]:
+        """ダウンロード先候補ディレクトリの全ファイルパスを返す。"""
+        result: set[str] = set()
+        for d in [_DOCS_DIR, "/sdcard/Download"]:
+            result |= self._list_dir(d)
+        return result
+
+    def _launch_app(self, d) -> None:
+        _adb(
+            "shell", "monkey",
+            "-p", _PACKAGE,
+            "-c", "android.intent.category.LAUNCHER",
+            "1",
+        )
+        _wait(3.0)
+
+    def _navigate_to_history(self, d) -> None:
+        # 取引ボタン（ボトムバー中央: view_bottom_item）
+        trade_btn = d(resourceId=f"{_PACKAGE}:id/view_bottom_item")
+        if trade_btn.exists:
+            trade_btn.click()
+            _wait(2.0)
+
+        # 帳票タブが見つからない場合は認証が必要 → 手動ログイン待ち
+        hyohyo_tab = d(resourceId=f"{_PACKAGE}:id/tabTitle", text="帳票")
+        if not hyohyo_tab.exists:
+            print(f"[{self.name}] 認証が必要です。アプリでログインして帳票タブが表示されたら Enter を押してください")
+            input("Enter: ")
+            _wait(1.0)
+            hyohyo_tab = d(resourceId=f"{_PACKAGE}:id/tabTitle", text="帳票")
+            if not hyohyo_tab.exists:
+                raise RuntimeError(f"[{self.name}] 帳票タブが見つかりません")
+
+        # 帳票タブ（タブバーの「履歴」ではなく「帳票」）
+        hyohyo_tab.click()
+        _wait(2.0)
+
+        # 帳票画面内の「履歴記録」行（全書類一覧へ）
+        rekishi = d(resourceId=f"{_PACKAGE}:id/tv_date", text="履歴記録")
+        if not rekishi.exists:
+            raise RuntimeError(f"[{self.name}] 履歴記録が見つかりません")
+        rekishi.click()
+        _wait(2.0)
+
+    def _find_and_tap_doc(self, d, target_year: int) -> bool:
+        """スクロールしながら対象ドキュメント行を探してタップ。見つかったら True。
+
+        tv_date が年度のみ（例: "2025"）の書類は特定口座年間取引報告書だけなので、
+        following-sibling で year_str との完全一致で絞り込む。
+        """
+        year_str = str(target_year)
+        xpath = (
+            f'//*[@resource-id="{_PACKAGE}:id/tv_name" and @text="{_TARGET_DOC}"]'
+            f'[following-sibling::*[@resource-id="{_PACKAGE}:id/tv_date"'
+            f' and @text="{year_str}"]]'
+        )
+        for attempt in range(15):
+            els = d.xpath(xpath).all()
+            if els:
+                els[0].click()
+                return True
+            print(f"[{self.name}] スクロール中... ({attempt + 1}/15)")
+            d.swipe(540, 1500, 540, 600, duration=0.4)
+            _wait(1.0)
+        return False
+
+    def _find_adb_serial(self) -> str:
+        """adb devices から接続済みデバイスのシリアルを返す。見つからなければ例外。"""
+        out = _adb("devices")
+        for line in out.splitlines()[1:]:
+            parts = line.strip().split()
+            if len(parts) == 2 and parts[1] == "device":
+                return parts[0]
+        raise RuntimeError(
+            "ADB デバイスが見つかりません。\n"
+            "先に以下を実行してください（ポートはワイヤレスデバッグ画面で確認）:\n"
+            "  adb connect <AndroidのIP>:<ポート番号>"
+        )
+
+    def collect(self, serial: str | None = None) -> None:
+        try:
+            import uiautomator2 as u2
+        except ImportError:
+            print(f"[{self.name}] uiautomator2 未インストール: pip install uiautomator2")
+            sys.exit(1)
+
+        target_year = self.config.get("target_year")
+        if target_year is None:
+            raise ValueError("target_year が設定されていません")
+
+        if serial is None:
+            serial = self._find_adb_serial()
+
+        d = u2.connect(serial)
+        print(f"[{self.name}] デバイス接続: {d.serial}")
+
+        try:
+            self._launch_app(d)
+            self._navigate_to_history(d)
+
+            files_before = self._snapshot()
+
+            print(f"[{self.name}] {_TARGET_DOC} ({target_year}) を検索中...")
+            if not self._find_and_tap_doc(d, target_year):
+                print(f"[{self.name}] {_TARGET_DOC} ({target_year}) が見つかりません")
+                return
+
+            # WebView 読み込み待ち
+            _wait(3.0)
+            webview = d(resourceId=f"{_PACKAGE}:id/webview")
+            if not webview.wait(timeout=15):
+                print(f"[{self.name}] WebView タイムアウト")
+                return
+            _wait(2.0)
+
+            # ダウンロードボタン（r2_menu_icon）
+            dl_btn = d(resourceId=f"{_PACKAGE}:id/r2_menu_icon")
+            if not dl_btn.exists:
+                print(f"[{self.name}] ダウンロードボタンが見つかりません")
+                return
+            dl_btn.click()
+
+            # フォルダ権限ダイアログ（初回のみ・2段階）: 最大10秒待ちながら検出→タップ
+            for _ in range(10):
+                _wait(1.0)
+                for btn_text in ["このフォルダを使用", "許可", "ALLOW", "Allow"]:
+                    btn = d(text=btn_text)
+                    if btn.exists:
+                        print(f"[{self.name}] 権限ダイアログ「{btn_text}」→ タップ")
+                        btn.click()
+                        _wait(0.5)
+
+            _wait(4.0)
+
+            # 新規ファイル特定（Documents と Download 両方チェック）
+            new_files = self._snapshot() - files_before
+            print(f"[{self.name}] 新規ファイル: {new_files or '(なし)'}")
+
+            if not new_files:
+                print(f"[{self.name}] ダウンロードファイルが見つかりません")
+                return
+            if len(new_files) > 1:
+                print(f"[{self.name}] 警告: 複数の新規ファイル: {new_files}")
+
+            remote_path = next(iter(new_files))
+
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            local_path = self.output_dir / f"{target_year}_webull_nentori.pdf"
+
+            print(f"[{self.name}] adb pull: {remote_path} → {local_path}")
+            _adb("pull", remote_path, str(local_path))
+
+            if not local_path.exists() or local_path.stat().st_size == 0:
+                print(f"[{self.name}] pull 失敗")
+                return
+
+            if local_path.read_bytes()[:4] != b"%PDF":
+                print(f"[{self.name}] PDF 検証失敗")
+                local_path.unlink(missing_ok=True)
+                return
+
+            print(f"[{self.name}] PDF 保存: {local_path}")
+
+            try:
+                data = convert_pdf_to_json(
+                    pdf_path=str(local_path),
+                    company=self.name,
+                    code=self.code,
+                    year=target_year,
+                    raw_files=[local_path.name],
+                )
+                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
+                with open(json_path, "w", encoding="utf-8") as f:
+                    json.dump(data, f, ensure_ascii=False, indent=2)
+                print(f"[{self.name}] JSON 保存: {json_path}")
+            except Exception as e:
+                print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+            print(f"[{self.name}] 完了")
+
+        finally:
+            _adb("shell", "am", "force-stop", _PACKAGE)
+            print(f"[{self.name}] アプリ終了")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="ウィブル証券 特定口座年間取引報告書収集")
+    parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--serial", default=None, help="ADB デバイスシリアル（省略時: adb devices から自動取得）")
+    args = parser.parse_args()
+    collector = WebullCollector(year=args.year)
+    collector.collect(serial=args.serial)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tax-collect/sites/webull/site.json
+++ b/skills/tax-collect/sites/webull/site.json
@@ -1,0 +1,10 @@
+{
+  "name": "ウィブル証券",
+  "code": "webull",
+  "has_xml": false,
+  "target_year": 2025,
+  "output_dir": "data/income/securities/webull/2025/raw/",
+"documents": [
+    { "type": "特定口座年間取引報告書" }
+  ]
+}


### PR DESCRIPTION
## Summary

- ADB + uiautomator2 でウィブル証券Androidアプリを操作し、特定口座年間取引報告書PDFを自動収集
- 帳票タブ → 履歴記録 → 対象行タップ → WebView → r2_menu_icon → adb pull の流れ
- フォルダ権限ダイアログ（2段階: 「このフォルダを使用」→「許可」）を自動タップ
- 処理完了後アプリを force-stop で終了
- PDF → JSON 変換（convert_pdf_to_json）対応
- USB接続推奨・ワイヤレス手順を README_ADB.md に追記

## Test plan

- [ ] USB ADB 接続で `adb devices` にデバイスが表示されることを確認
- [ ] `python skills/tax-collect/sites/webull/collect.py --year 2025` が完了すること
- [ ] `data/income/securities/webull/2025/raw/2025_webull_nentori.pdf` が保存されること
- [ ] `data/income/securities/webull/2025/nenkantorihikihokokusho.json` が保存されること
- [ ] 処理後アプリが終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)