### PR TITLE
refactor: #34 tax-collect 全社コードレビュー対応 + 不具合修正

### DIFF
--- a/.workbench/alias_rules
+++ b/.workbench/alias_rules
@@ -10,3 +10,6 @@ adb           C:\Users\g\AppData\Local\Microsoft\WinGet\Packages\Google.Platform
 format        $VENV_PYTHON -m black . ; $VENV_PYTHON -m isort .  # black で整形 → isort で import 整理
 lint          $VENV_PYTHON -m mypy . ; $VENV_PYTHON -m pylint --recursive=y .  # 型チェック → 静的解析
 test          $VENV_PYTHON -m pytest @args  # pytest 実行
+tax-collect   $VENV_PYTHON $PROJECT_ROOT/skills/tax-collect/run.py @args  # tax-collect 一括収集
+tax-convert   $VENV_PYTHON $PROJECT_ROOT/skills/tax-collect/convert.py @args  # PDF→JSON 直列変換（30秒delay）
+tax-recorder  $VENV_PYTHON $PROJECT_ROOT/skills/tax-collect/recorder.py @args  # 新規サイト追加用 操作記録

--- a/plan/20260424_0006_tax-collect-code-review.md
+++ b/plan/20260424_0006_tax-collect-code-review.md
@@ -1,0 +1,128 @@
+# tax-collect 全社コードレビュー 対応プラン
+
+作成: 2026-04-24  
+レビュー: Claude Opus（全15社 collect.py + BaseCollector 精査）  
+前提: 動作確認済みコード。順次実装のため後発機能が古い社に未反映。
+
+---
+
+## BUG — 即対処
+
+### B-1: monex dead code 削除
+- ファイル: `skills/tax-collect/sites/monex/collect.py`
+- 問題: `_download_pdf_via_route` が `return` 後に `captured` 未定義変数参照ブロックが残存
+- 修正: 到達不能ブロックを削除
+
+### B-2: webull 個人パスハードコード除去
+- ファイル: `skills/tax-collect/sites/webull/collect.py`
+- 問題: `_ADB_FALLBACK` に `C:\Users\g\AppData\...` ハードコード
+- 修正: 環境変数 `ADB_PATH` から読み込む。未設定時はエラーメッセージで終了
+
+### B-3: gmo-click expect_popup タイムアウトリスク
+- ファイル: `skills/tax-collect/sites/gmo-click/collect.py`
+- 問題: `with expect_popup():` 内で `input()` 待機 → 30秒デフォルトタイムアウトで死ぬ
+- 修正: `input()` を `with` 外（popup open前）に移動 or `expect_popup(timeout=0)` 指定
+
+### B-4: download failure 未検証（全社）
+- 対象: sbi / rakuten / nomura / monex / matsui / gmo-click / smbcnikko（sawakami は対応済み）
+- 問題: `save_as()` 成功 = 正常保存とみなし、0バイトや失敗を検知しない
+- 修正: `download.failure()` チェック + PDF は `%PDF` マジックバイト確認を `BaseCollector` 共通ヘルパに追加
+
+---
+
+## MISSING — 機能非対称修正
+
+### M-1: storage_state 保存（rakuten / nomura / smbcnikko）
+- 問題: session cookie を保存しないため re-login 時に 2FA が毎回必要
+- 修正: SBI 実装と同様に `_wait_for_login` 末尾で `storage_state` 保存を追加
+
+### M-2: cookie 空時の保存スキップを BaseCollector に昇格
+- 問題: mufg-esmart / sawakami だけガード有り。他社は空 storage_state で既存ファイルを破壊リスク
+- 修正: `BaseCollector._save_session_state(page)` ヘルパを追加。cookie 0件時は保存スキップ。各社から呼ぶ
+
+### M-3: `_is_logged_in` 自動スキップ（sbi / rakuten / nomura / monex / matsui / gmo-click / smbcnikko / hifumi）
+- 問題: セッションが生きていても login 待ち `input()` が毎回発生
+- 修正: 各社の `_wait_for_login` に「URL/要素で判定 → 既にログイン済みならスキップ」ロジックを追加（各社のトップ画面 URL or ログイン後に現れる要素で判定）
+
+### M-4: webull に log_result を追加
+- 問題: `BaseCollector` 未継承のため log_result が呼ばれずランナー統合不可
+- 修正: 最低限 `BaseCollector` を継承する（adb ベースの処理は維持）。または `log_result` 相当を独自実装してインターフェース合わせ
+
+### M-5: dlog/save_html を sbi / rakuten / matsui / gmo-click に追加
+- 問題: 後発社だけデバッグログ対応。古い4社はデバッグ不能
+- 修正: `dlog` / `save_html` 呼び出しを主要ステップに追加
+
+---
+
+## REFACTOR — 共通化
+
+### R-1: `_wait()` を BaseCollector または utils に共通化
+- 問題: `time.sleep(random.uniform(lo, hi))` が15ファイルにコピー
+- 修正: `BaseCollector._wait(lo, hi)` or `money_ops.utils.wait(lo, hi)` に移動。各社の `_wait =` 削除
+
+### R-2: `_RE_FILENAME` / `_extract_filename()` を utils に共通化
+- 問題: `re.compile(r'filename[^;=\n]*=...')` が9社にコピー
+- 修正: `money_ops.utils.http.extract_filename(response, fallback)` ヘルパに抽出
+
+### R-3: e-shishobako PDF 捕捉ヘルパ抽出
+- 対象: sbi / gmo-click / nomura / hifumi（同一の DPAW010501020 route パターン）
+- 修正: `money_ops.collector.eshishobako.capture_pdf(scope, fallback_name)` に共通化
+
+### R-4: `_convert_to_json` + `_write_report_json` を BaseCollector に
+- 問題: JSON書き出しボイラープレートが全社コピー
+- 修正: `BaseCollector._write_report_json(data: dict)` を追加。各社は data を渡すだけ
+
+### R-5: `collect()` スケルトンを Template Method 化
+- 問題: `try/except KeyboardInterrupt/Exception/finally close_browser` が全社コピー
+- 修正: `BaseCollector.run()` にスケルトン実装。各社は `_collect_core()` のみ実装
+
+### R-6: `__init__` の year / output_dir 構築を BaseCollector に移動
+- 問題: `self.config["target_year"] = year` / `output_dir = f"data/.../code/year/raw/"` が全社コピー
+- 修正: `BaseCollector.__init__(site_json, year=None)` に `year` パラメータを追加。config mutation も廃止
+
+---
+
+## DESIGN — 設計改善（中長期）
+
+### D-1: `sys.path.insert` を `pip install -e .` に統一
+- 問題: `Path(__file__).parents[4]` の深さ依存でディレクトリ移動で壊れる
+- 修正: 開発環境セットアップドキュメントに `pip install -e .` を明記し、path 注入を削除
+
+### D-2: `site.json` に login_url / converter_type を集約
+- 問題: `_LOGIN_URL` 等の定数がコードにハードコード。URL変更時にコード修正が必要
+- 修正: `site.json` に `login_url`, `converter_type: "teg204_xml" | "pdf_llm"` を追加。BaseCollector が dispatch
+
+### D-3: `input()` を PromptStrategy に抽象化（並列化の布石）
+- 問題: `input()` がコード深部に散在。CLAUDE.md 要件の並列収集 Subagents 対応不可
+- 修正: `PromptStrategy` 抽象（InteractivePrompt / EnvPrompt）を設計。ランナーから注入
+
+### D-4: `HEADLESS` / `DEBUG` を CLI 引数化
+- 問題: 全社共通グローバルフラグで社別制御不可
+- 修正: `--headless` / `--debug` を argparse に追加し環境変数より優先
+
+---
+
+## 実装優先度
+
+| Pri | Issue 候補 | 工数感 |
+|-----|-----------|--------|
+| **High** | B-1: monex dead code | 小 |
+| **High** | B-2: webull ADB パスハードコード | 小 |
+| **High** | B-3: gmo-click expect_popup | 小 |
+| **High** | B-4: download failure 検証 + BaseCollector ヘルパ | 中 |
+| **High** | M-2: cookie 空保護を BaseCollector に昇格 | 小 |
+| **High** | M-4: webull log_result | 小 |
+| Mid | R-1〜R-6: 共通化 | 中〜大 |
+| Mid | M-1: storage_state（rakuten/nomura/smbcnikko） | 小 |
+| Mid | M-3: `_is_logged_in` 追加 | 中（社ごと） |
+| Mid | M-5: dlog 追加（古い4社） | 小 |
+| Low | D-1〜D-4: 設計改善 | 大 |
+
+---
+
+## 関連ファイル
+
+- `src/money_ops/collector/base.py` — BaseCollector
+- `skills/tax-collect/sites/*/collect.py` — 各社スクリプト
+- `skills/tax-collect/registry.json` — 会社定義
+- `skills/tax-collect/run.py` — 一括実行ランナー

--- a/plan/20260424_0006_tax-collect-code-review.md
+++ b/plan/20260424_0006_tax-collect-code-review.md
@@ -64,19 +64,19 @@
 - 問題: `re.compile(r'filename[^;=\n]*=...')` が9社にコピー
 - 修正: `money_ops.utils.http.extract_filename(response, fallback)` ヘルパに抽出
 
-### R-3: e-shishobako PDF 捕捉ヘルパ抽出
+### R-3: e-shishobako PDF 捕捉ヘルパ抽出 [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 対象: sbi / gmo-click / nomura / hifumi（同一の DPAW010501020 route パターン）
 - 修正: `money_ops.collector.eshishobako.capture_pdf(scope, fallback_name)` に共通化
 
-### R-4: `_convert_to_json` + `_write_report_json` を BaseCollector に
+### R-4: `_convert_to_json` + `_write_report_json` を BaseCollector に [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: JSON書き出しボイラープレートが全社コピー
 - 修正: `BaseCollector._write_report_json(data: dict)` を追加。各社は data を渡すだけ
 
-### R-5: `collect()` スケルトンを Template Method 化
+### R-5: `collect()` スケルトンを Template Method 化 [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: `try/except KeyboardInterrupt/Exception/finally close_browser` が全社コピー
 - 修正: `BaseCollector.run()` にスケルトン実装。各社は `_collect_core()` のみ実装
 
-### R-6: `__init__` の year / output_dir 構築を BaseCollector に移動
+### R-6: `__init__` の year / output_dir 構築を BaseCollector に移動 [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: `self.config["target_year"] = year` / `output_dir = f"data/.../code/year/raw/"` が全社コピー
 - 修正: `BaseCollector.__init__(site_json, year=None)` に `year` パラメータを追加。config mutation も廃止
 
@@ -84,19 +84,19 @@
 
 ## DESIGN — 設計改善（中長期）
 
-### D-1: `sys.path.insert` を `pip install -e .` に統一
+### D-1: `sys.path.insert` を `pip install -e .` に統一 [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: `Path(__file__).parents[4]` の深さ依存でディレクトリ移動で壊れる
 - 修正: 開発環境セットアップドキュメントに `pip install -e .` を明記し、path 注入を削除
 
-### D-2: `site.json` に login_url / converter_type を集約
+### D-2: `site.json` に login_url / converter_type を集約 [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: `_LOGIN_URL` 等の定数がコードにハードコード。URL変更時にコード修正が必要
 - 修正: `site.json` に `login_url`, `converter_type: "teg204_xml" | "pdf_llm"` を追加。BaseCollector が dispatch
 
-### D-3: `input()` を PromptStrategy に抽象化（並列化の布石）
+### D-3: `input()` を PromptStrategy に抽象化（並列化の布石） [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: `input()` がコード深部に散在。CLAUDE.md 要件の並列収集 Subagents 対応不可
 - 修正: `PromptStrategy` 抽象（InteractivePrompt / EnvPrompt）を設計。ランナーから注入
 
-### D-4: `HEADLESS` / `DEBUG` を CLI 引数化
+### D-4: `HEADLESS` / `DEBUG` を CLI 引数化 [完了 branch:feature/34_tax-collect-code-review 2026-04-24]
 - 問題: 全社共通グローバルフラグで社別制御不可
 - 修正: `--headless` / `--debug` を argparse に追加し環境変数より優先
 

--- a/plan/20260424_0006_tax-collect-code-review.md
+++ b/plan/20260424_0006_tax-collect-code-review.md
@@ -100,6 +100,28 @@
 - 問題: 全社共通グローバルフラグで社別制御不可
 - 修正: `--headless` / `--debug` を argparse に追加し環境変数より優先
 
+### D-5: `prompt()` / `input()` を `page.wait_for_url()` / `wait_for_event()` に置換（全社）
+- 問題: `input()` が Bash ツール経由で EOF → Claude Codeスキルからの実行が不可能
+- 根本解決: Enter待ちをやめ、ブラウザ状態（URL・要素・イベント）を自身で検出する
+  - ログイン待ち → `page.wait_for_url(dashboard_pattern, timeout=300_000)`
+  - 2FA後のポップアップ待ち → `session.wait_for_event("popup", timeout=300_000)`
+  - OTP入力 → ユーザーがブラウザ直接入力・送信 → `page.wait_for_url()` で継続検出（スクリプトは fill/click 不要）
+- GMO-click で動作確認済み（2026-04-24）: signal ファイル不要・チャット完結・ターミナル実行と共存
+
+#### 全23箇所の分類（調査済み）
+
+**カテゴリA: ログイン・ダッシュボード到達待ち（13箇所）→ `wait_for_url`**
+- gmo-click, hifumi, matsui, monex, nomura, nomura-mochikabu, rakuten, sbi, smbcnikko, tsumiki, sawakami, paypay, webull(別途)
+
+**カテゴリB: OTP/認証コード（5箇所）→ ユーザーがブラウザ直接入力+送信 → `wait_for_url`**
+- daiwa-connect:84, mufg-esmart:121, paypay:103, sawakami:108, tsumiki:120
+- スクリプト側の `page.fill(code)` + `click()` を削除。ブラウザで完結させる。
+
+**カテゴリC: 中間フロー確認（5箇所）→ `wait_for_url` or `wait_for_selector` or `wait_for_event`**
+- daiwa-connect:90, mufg-esmart:131/141, nomura:70, gmo-click:74（実装済み）
+
+**webull**: Android/ADB のため別途検討
+
 ---
 
 ## 実装優先度

--- a/plan/20260424_0006_tax-collect-code-review.md
+++ b/plan/20260424_0006_tax-collect-code-review.md
@@ -1,4 +1,4 @@
-# tax-collect 全社コードレビュー 対応プラン
+# tax-collect 全社コードレビュー 対応プラン [完了 PR#37 2026-04-26]
 
 作成: 2026-04-24  
 レビュー: Claude Opus（全15社 collect.py + BaseCollector 精査）  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ check_untyped_defs = true
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v"
-asyncio_mode = "auto"
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/skills/tax-collect/SKILL.md
+++ b/skills/tax-collect/SKILL.md
@@ -83,6 +83,12 @@ python skills/tax-collect/create_zero_json.py --year <YEAR>
 
 `data/income/securities/<code>/<year>/nenkantorihikihokokusho.json` の存在で判断。
 
+## 前提条件
+
+- `money_ops` パッケージがインストール済みであること（`pip install -e .` を実行済み）
+- 各 `collect.py` は `money_ops` がインストールされた環境の Python で実行する必要がある
+- `run.py` は `sys.executable` で子プロセスを起動するため環境は自動引き継ぎされる
+
 ## 注意事項
 
 - ブラウザが起動したらユーザーが手動でログイン・2FA処理を行う

--- a/skills/tax-collect/SKILL.md
+++ b/skills/tax-collect/SKILL.md
@@ -19,7 +19,7 @@ description: >
 
 ### 2. 実行
 
-確認後、Bash ツールで **バックグラウンド実行**する:
+確認後、以下を実行する:
 
 ```bash
 python skills/tax-collect/run.py --year <YEAR> [オプション]
@@ -30,27 +30,9 @@ python skills/tax-collect/run.py --year <YEAR> [オプション]
 - `--force` — 収集済みでも再実行
 - `--fail-fast` — 1社エラーで即停止
 
-**run_in_background: true** で起動後、以下のシグナルファイルループを回す:
-
-#### シグナルファイル待機ループ（1社ごとに繰り返す）
-
-1. `.waiting_<code>` ファイルが出現するまでポーリング（Bash でチェック）
-2. 出現したら内容（ログイン待ちメッセージ）を読んでユーザーに表示
-3. **AskUserQuestion** で「ログイン完了したら教えてください」と確認
-4. ユーザーが完了を伝えたら `.signal_<code>` ファイルを作成
-5. 次の `.waiting_*` を待つ。全社完了まで繰り返す
-
-```bash
-# シグナルファイルポーリング例
-ls .waiting_* 2>/dev/null
-
-# シグナル送信
-echo "" > .signal_sbi
-```
-
 ### 3. 結果報告
 
-run.py プロセス終了後、サマリー（OK / ERROR / DONE / SKIP）をユーザーに報告する。
+実行後、サマリー（OK / ERROR / DONE / SKIP）をユーザーに報告する。
 ERRORが出た場合は内容を確認してユーザーに伝える。
 
 ---

--- a/skills/tax-collect/SKILL.md
+++ b/skills/tax-collect/SKILL.md
@@ -19,7 +19,7 @@ description: >
 
 ### 2. 実行
 
-確認後、以下を実行する:
+確認後、Bash ツールで **バックグラウンド実行**する:
 
 ```bash
 python skills/tax-collect/run.py --year <YEAR> [オプション]
@@ -30,9 +30,27 @@ python skills/tax-collect/run.py --year <YEAR> [オプション]
 - `--force` — 収集済みでも再実行
 - `--fail-fast` — 1社エラーで即停止
 
+**run_in_background: true** で起動後、以下のシグナルファイルループを回す:
+
+#### シグナルファイル待機ループ（1社ごとに繰り返す）
+
+1. `.waiting_<code>` ファイルが出現するまでポーリング（Bash でチェック）
+2. 出現したら内容（ログイン待ちメッセージ）を読んでユーザーに表示
+3. **AskUserQuestion** で「ログイン完了したら教えてください」と確認
+4. ユーザーが完了を伝えたら `.signal_<code>` ファイルを作成
+5. 次の `.waiting_*` を待つ。全社完了まで繰り返す
+
+```bash
+# シグナルファイルポーリング例
+ls .waiting_* 2>/dev/null
+
+# シグナル送信
+echo "" > .signal_sbi
+```
+
 ### 3. 結果報告
 
-実行後、サマリー（OK / ERROR / DONE / SKIP）をユーザーに報告する。
+run.py プロセス終了後、サマリー（OK / ERROR / DONE / SKIP）をユーザーに報告する。
 ERRORが出た場合は内容を確認してユーザーに伝える。
 
 ---

--- a/skills/tax-collect/convert.py
+++ b/skills/tax-collect/convert.py
@@ -1,0 +1,139 @@
+"""tax-collect PDF→JSON 変換ランナー（直列・delay付き）
+
+使い方:
+    python skills/tax-collect/convert.py --year 2025
+    python skills/tax-collect/convert.py --year 2025 --codes webull mufg-esmart
+    python skills/tax-collect/convert.py --retry        # *.queue.err も再対象
+    python skills/tax-collect/convert.py --delay-sec 60  # 各変換後の待機秒数
+
+動作:
+    output/converting/*.queue（および --retry 時 *.queue.err）を列挙し、
+    convert_worker.py を順次同期実行する。
+    成功で queue 削除、失敗で <code>_<year>.queue.err にリネーム。
+    各変換完了後 delay-sec 秒待機（Gemini API レート制限対策）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+_SKILLS_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SKILLS_DIR.parents[1]
+_QUEUE_DIR = _PROJECT_ROOT / "output" / "converting"
+_WORKER = _SKILLS_DIR / "convert_worker.py"
+
+
+def _load_queue(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"[convert] queue 読込失敗: {path.name} ({e})")
+        return None
+
+
+def _list_queues(year: int | None, codes: list[str] | None, retry: bool) -> list[Path]:
+    if not _QUEUE_DIR.exists():
+        return []
+    paths = sorted(_QUEUE_DIR.glob("*.queue"))
+    if retry:
+        paths += sorted(_QUEUE_DIR.glob("*.queue.err"))
+    result: list[Path] = []
+    for p in paths:
+        data = _load_queue(p)
+        if data is None:
+            continue
+        if year is not None and data.get("year") != year:
+            continue
+        if codes and data.get("code") not in codes:
+            continue
+        result.append(p)
+    return result
+
+
+def _run_one(queue_path: Path) -> bool:
+    data = _load_queue(queue_path)
+    if data is None:
+        return False
+    code = data["code"]
+    year = data["year"]
+    company = data["company"]
+    pdf_path = data["pdf_path"]
+    raw_files = data.get("raw_files", [])
+
+    print(f"\n[convert] {code} ({company}) 開始 {datetime.now().strftime('%H:%M:%S')}")
+    print(f"[convert]   PDF: {pdf_path}")
+    cmd = [
+        sys.executable, str(_WORKER),
+        "--pdf", pdf_path,
+        "--code", code,
+        "--year", str(year),
+        "--company", company,
+    ]
+    if raw_files:
+        cmd += ["--raw-files", *raw_files]
+
+    result = subprocess.run(cmd, stdout=sys.stdout, stderr=sys.stderr)
+    if result.returncode == 0:
+        try:
+            queue_path.unlink()
+        except OSError:
+            pass
+        print(f"[convert] {code} 成功 → queue 削除")
+        return True
+
+    err_path = queue_path.with_suffix(".queue.err") if queue_path.suffix == ".queue" else queue_path
+    if err_path != queue_path:
+        try:
+            queue_path.rename(err_path)
+        except OSError:
+            pass
+    print(f"[convert] {code} 失敗 (rc={result.returncode}) → {err_path.name}")
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PDF→JSON 変換ランナー（直列）")
+    parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--codes", nargs="+", metavar="CODE")
+    parser.add_argument("--retry", action="store_true", help="*.queue.err も対象")
+    parser.add_argument("--delay-sec", type=int, default=30)
+    args = parser.parse_args()
+
+    queues = _list_queues(args.year, args.codes, args.retry)
+    if not queues:
+        print("[convert] 対象キューなし")
+        return 0
+
+    print(f"[convert] 対象 {len(queues)} 件 / 各変換後 delay={args.delay_sec}s")
+    for p in queues:
+        print(f"  - {p.name}")
+
+    ok = 0
+    ng = 0
+    for i, q in enumerate(queues, 1):
+        print(f"\n{'='*60}")
+        print(f"[convert] {i}/{len(queues)}")
+        print(f"{'='*60}")
+        if _run_one(q):
+            ok += 1
+        else:
+            ng += 1
+        if i < len(queues):
+            print(f"[convert] delay {args.delay_sec}s ...")
+            time.sleep(args.delay_sec)
+
+    print(f"\n{'='*60}")
+    print(f"=== 変換結果 ===")
+    print(f"  成功: {ok} / 失敗: {ng}")
+    print(f"{'='*60}")
+    return 0 if ng == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/tax-collect/convert_worker.py
+++ b/skills/tax-collect/convert_worker.py
@@ -1,0 +1,91 @@
+"""PDF → JSON 変換ワーカー（B案: 並列化用デタッチ実行）
+
+使い方:
+    python convert_worker.py --pdf <path> --code <code> --year <year> \
+        --company <company> [--raw-files name1 name2 ...]
+
+動作:
+    - 起動直後に lock ファイル output/converting/<code>_<year>.lock を作成
+    - docling 経由 PDF→JSON 変換
+    - 結果を data/income/securities/<code>/<year>/nenkantorihikihokokusho.json に保存
+    - ハートビート: 10秒ごとに「[CONVERT][<code>] 経過Xs」を stderr に出す
+    - 終了時（成功・失敗問わず）lock ファイルを削除
+
+run.py から detach 起動され、tax-collect 全社走行と並列に動作する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+import traceback
+from pathlib import Path
+
+_LOCK_DIR = Path("output") / "converting"
+
+
+def _heartbeat(code: str, stop_event: threading.Event, interval: int = 10) -> None:
+    start = time.time()
+    while not stop_event.wait(interval):
+        elapsed = int(time.time() - start)
+        print(f"[CONVERT][{code}] 変換中... 経過{elapsed}s", file=sys.stderr, flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pdf", required=True)
+    parser.add_argument("--code", required=True)
+    parser.add_argument("--year", type=int, required=True)
+    parser.add_argument("--company", required=True)
+    parser.add_argument("--raw-files", nargs="*", default=[])
+    args = parser.parse_args()
+
+    _LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    lock_path = _LOCK_DIR / f"{args.code}_{args.year}.lock"
+    lock_path.write_text(f"{args.pdf}\n", encoding="utf-8")
+
+    stop_event = threading.Event()
+    hb = threading.Thread(target=_heartbeat, args=(args.code, stop_event), daemon=True)
+    hb.start()
+
+    rc = 0
+    try:
+        print(f"[CONVERT][{args.code}] 開始: {args.pdf}", file=sys.stderr, flush=True)
+        from money_ops.converter.pdf_to_json import convert_pdf_to_json
+
+        data = convert_pdf_to_json(
+            pdf_path=args.pdf,
+            company=args.company,
+            code=args.code,
+            year=args.year,
+            raw_files=args.raw_files,
+        )
+
+        out_dir = Path("data") / "income" / "securities" / args.code / str(args.year)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        json_path = out_dir / "nenkantorihikihokokusho.json"
+        json_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(
+            f"[CONVERT][{args.code}] 完了: {json_path}", file=sys.stderr, flush=True
+        )
+    except Exception as e:
+        rc = 1
+        print(f"[CONVERT][{args.code}] エラー: {e}", file=sys.stderr, flush=True)
+        traceback.print_exc(file=sys.stderr)
+    finally:
+        stop_event.set()
+        try:
+            lock_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/tax-collect/recorder.py
+++ b/skills/tax-collect/recorder.py
@@ -1,0 +1,260 @@
+"""tax-collect サイト追加用 操作記録ツール
+
+使い方:
+    python skills/tax-collect/recorder.py --code newsite --start-url https://example.com/
+
+動作:
+    1. Playwright persistent context（既存プロファイル使用）でブラウザ起動
+    2. tracing / HAR / イベントフックを開始
+    3. ユーザーがブラウザで対象サイトを操作・PDF DL まで実施
+    4. ターミナルで Enter キー（任意ラベル可）で「マイルストーン」記録 + DOM dump
+    5. 'q' + Enter で停止 → output/recorder/<code>/<timestamp>/ に成果物保存
+
+成果物:
+    trace.zip       Playwright Trace Viewer で操作再現（スクショ+DOM+ソース）
+    network.har     全ネットワーク（リクエスト・レスポンス・ヘッダ・cookie）
+    events.jsonl    framenavigated / popup / download / dialog / console の時系列
+    dom_*.html      マイルストーン地点と最終地点の DOM スナップショット
+    milestones.txt  ユーザーが Enter で記録したラベル一覧
+    summary.md      URL 推移・popup・download の要約（実装の起点）
+
+注意:
+    既存の persistent context（~/.money-ops-browser/<code>/）を流用するため、
+    過去にログイン済みなら cookie/storage が引き継がれる。新規プロファイル使用時は
+    --fresh で別ディレクトリを使う。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+from datetime import datetime
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _now() -> str:
+    return datetime.now().isoformat()
+
+
+def _write_summary(out_dir: Path, events: list[dict], milestones: list[dict]) -> None:
+    nav = [e for e in events if e["kind"] == "framenavigated"]
+    popups = [e for e in events if e["kind"] == "popup"]
+    downloads = [e for e in events if e["kind"] == "download"]
+    dialogs = [e for e in events if e["kind"] == "dialog"]
+
+    lines: list[str] = []
+    lines.append(f"# recorder summary\n")
+    lines.append(f"- generated: {_now()}\n")
+    lines.append(f"- events: {len(events)} / nav: {len(nav)} / popup: {len(popups)} / download: {len(downloads)} / dialog: {len(dialogs)}\n")
+
+    lines.append("\n## milestones\n")
+    if milestones:
+        for i, m in enumerate(milestones, 1):
+            lines.append(f"{i}. `{m['ts']}` — {m['label']}\n")
+    else:
+        lines.append("(なし)\n")
+
+    lines.append("\n## URL 遷移（main frame）\n")
+    seen_url: set[str] = set()
+    for e in nav:
+        u = e.get("url", "")
+        if u in seen_url:
+            continue
+        seen_url.add(u)
+        lines.append(f"- `{e['ts']}` {u}\n")
+
+    lines.append("\n## popup\n")
+    for e in popups:
+        lines.append(f"- `{e['ts']}` {e.get('url', '')}\n")
+    if not popups:
+        lines.append("(なし)\n")
+
+    lines.append("\n## download\n")
+    for e in downloads:
+        lines.append(f"- `{e['ts']}` suggested=`{e.get('suggested', '')}` url={e.get('url', '')}\n")
+    if not downloads:
+        lines.append("(なし)\n")
+
+    lines.append("\n## dialog\n")
+    for e in dialogs:
+        lines.append(f"- `{e['ts']}` type={e.get('type', '')} message={e.get('message', '')[:200]}\n")
+    if not dialogs:
+        lines.append("(なし)\n")
+
+    (out_dir / "summary.md").write_text("".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="tax-collect サイト追加用 操作記録ツール")
+    parser.add_argument("--code", required=True, help="サイトコード（例: newsite）")
+    parser.add_argument("--start-url", default=None, help="起動時に開く URL")
+    parser.add_argument("--fresh", action="store_true", help="新規プロファイル使用（既存cookie流用しない）")
+    args = parser.parse_args()
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = _PROJECT_ROOT / "output" / "recorder" / args.code / ts
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[recorder] 出力先: {out_dir}")
+
+    if args.fresh:
+        profile_dir = _PROJECT_ROOT / "output" / "recorder" / args.code / f"profile_{ts}"
+    else:
+        profile_dir = Path.home() / ".money-ops-browser" / args.code
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[recorder] プロファイル: {profile_dir}")
+
+    import queue as _queue
+
+    events: list[dict] = []
+    milestones: list[dict] = []
+    dom_seq = [0]
+    stop_event = threading.Event()
+    state: dict = {}
+    milestone_queue: _queue.Queue[str] = _queue.Queue()
+
+    def add_event(kind: str, **data) -> None:
+        e = {"ts": _now(), "kind": kind, **data}
+        events.append(e)
+        sig = data.get("url") or data.get("label") or data.get("suggested") or ""
+        print(f"[event] {kind}: {sig}")
+
+    def save_dom(page, label: str) -> None:
+        dom_seq[0] += 1
+        seq = dom_seq[0]
+        try:
+            html = page.content()
+            url = page.url
+        except Exception as e:
+            print(f"[recorder] DOM 保存失敗 ({label}): {e}")
+            return
+        path = out_dir / f"dom_{seq:03d}_{label}.html"
+        path.write_text(html, encoding="utf-8")
+        add_event("dom_dump", file=path.name, url=url, label=label)
+
+    def attach_page_events(page) -> None:
+        page.on(
+            "framenavigated",
+            lambda f: add_event("framenavigated", url=f.url) if f == f.page.main_frame else None,
+        )
+        def on_popup(p):
+            add_event("popup", url=p.url)
+            attach_page_events(p)
+        page.on("popup", on_popup)
+        page.on("download", lambda d: add_event("download", suggested=d.suggested_filename, url=d.url))
+        page.on("dialog", lambda d: add_event("dialog", type=d.type, message=d.message))
+        page.on("console", lambda m: add_event("console", level=m.type, text=m.text[:300]))
+
+    def input_loop() -> None:
+        print("\n[recorder] 操作開始。Enter=milestone（ラベル任意） / 'q'+Enter=停止\n")
+        while not stop_event.is_set():
+            try:
+                line = input()
+            except EOFError:
+                stop_event.set()
+                break
+            if line.strip().lower() == "q":
+                stop_event.set()
+                break
+            label = line.strip() or f"milestone_{len(milestones)+1}"
+            milestones.append({"ts": _now(), "label": label})
+            print(f"[milestone] {label} (DOM保存待機中...)")
+            milestone_queue.put(label)
+
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        context = p.chromium.launch_persistent_context(
+            str(profile_dir),
+            headless=False,
+            record_har_path=str(out_dir / "network.har"),
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--use-angle=d3d11",
+            ],
+            ignore_default_args=["--enable-automation"],
+        )
+        context.tracing.start(screenshots=True, snapshots=True, sources=True)
+        page = context.new_page()
+        state["page"] = page
+        attach_page_events(page)
+
+        if args.start_url:
+            page.goto(args.start_url)
+
+        def on_context_close():
+            if not stop_event.is_set():
+                print("\n[recorder] ブラウザが閉じられました → 停止")
+                stop_event.set()
+
+        context.on("close", lambda: on_context_close())
+
+        thread = threading.Thread(target=input_loop, daemon=True)
+        thread.start()
+
+        try:
+            while not stop_event.is_set():
+                try:
+                    label = milestone_queue.get(timeout=0.2)
+                except _queue.Empty:
+                    # CDP イベントポンプ: 新 popup target の waitForDebugger 解除のため
+                    # 短い Playwright API 呼び出しでメッセージキューを drain
+                    try:
+                        for pg in context.pages:
+                            if not pg.is_closed():
+                                pg.evaluate("1")
+                    except Exception:
+                        pass
+                    continue
+                pages = [pg for pg in context.pages if not pg.is_closed()]
+                for i, pg in enumerate(pages):
+                    suffix = f"milestone_{label}_p{i}" if len(pages) > 1 else f"milestone_{label}"
+                    try:
+                        save_dom(pg, suffix)
+                    except Exception as e:
+                        print(f"[recorder] milestone DOM 保存失敗 ({suffix}): {e}")
+        except KeyboardInterrupt:
+            print("\n[recorder] Ctrl+C 検出 → 停止")
+            stop_event.set()
+
+        print("[recorder] tracing 停止中（trace.zip 生成）...")
+        try:
+            for i, pg in enumerate([p for p in context.pages if not p.is_closed()]):
+                suffix = f"final_p{i}" if len(context.pages) > 1 else "final"
+                try:
+                    save_dom(pg, suffix)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        try:
+            context.tracing.stop(path=str(out_dir / "trace.zip"))
+            print("[recorder] trace.zip 保存完了")
+        except Exception as e:
+            print(f"[recorder] tracing 停止失敗（ブラウザ既閉鎖）: {e}")
+        try:
+            context.close()
+        except Exception:
+            pass
+
+    (out_dir / "events.jsonl").write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in events) + ("\n" if events else ""),
+        encoding="utf-8",
+    )
+    (out_dir / "milestones.txt").write_text(
+        "\n".join(f"{m['ts']}\t{m['label']}" for m in milestones) + ("\n" if milestones else ""),
+        encoding="utf-8",
+    )
+    _write_summary(out_dir, events, milestones)
+
+    print(f"\n[recorder] 完了 → {out_dir}")
+    print("  - trace.zip    : npx playwright show-trace で再生")
+    print("  - network.har  : HAR Viewer / Chrome DevTools")
+    print("  - summary.md   : 実装起点（URL推移・popup・DL要約）")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tax-collect/registry.json
+++ b/skills/tax-collect/registry.json
@@ -1,6 +1,18 @@
 {
   "securities": [
     {
+      "code": "webull",
+      "name": "ウィブル証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": null,
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "android",
+      "login_detection": null
+    },
+    {
       "code": "sbi",
       "name": "SBI証券",
       "document_type": "特定口座年間取引報告書",
@@ -20,14 +32,14 @@
       "name": "楽天証券",
       "document_type": "特定口座年間取引報告書",
       "site_url": "https://www.rakuten-sec.co.jp/",
-      "login_url": "https://www.rakuten-sec.co.jp/",
-      "dashboard_url": "https://www.rakuten-sec.co.jp/",
+      "login_url": "https://member.rakuten-sec.co.jp/app/MhLogin.do?login_type=1",
+      "dashboard_url": "https://member.rakuten-sec.co.jp/app/home",
       "has_xml": true,
       "マイナ連携": false,
       "collection": "auto",
       "login_detection": {
-        "done_selector": "button[aria-label*='マイメニュー']",
-        "skip_selector": "button[aria-label*='マイメニュー']"
+        "done_url": "**/member.rakuten-sec.co.jp/app/**",
+        "skip_url_contains": "member.rakuten-sec.co.jp/app/"
       }
     },
     {
@@ -51,13 +63,12 @@
       "document_type": "特定口座年間取引報告書",
       "site_url": "https://www.monex.co.jp/",
       "login_url": "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp",
-      "dashboard_url": "https://mst.monex.co.jp/",
+      "dashboard_url": "https://mxp3.monex.co.jp/",
       "has_xml": true,
       "マイナ連携": true,
       "collection": "auto",
       "login_detection": {
-        "skip_url_contains": "mst.monex.co.jp",
-        "skip_url_excludes": "LoginIDPassword"
+        "skip_url_contains": "mxp3.monex.co.jp"
       }
     },
     {
@@ -65,8 +76,8 @@
       "name": "松井証券",
       "document_type": "特定口座年間取引報告書",
       "site_url": "https://www.matsui.co.jp/",
-      "login_url": "https://www.matsui.co.jp/",
-      "dashboard_url": "https://www.matsui.co.jp/",
+      "login_url": "https://www.deal.matsui.co.jp/ITS/login/MemberLogin.jsp",
+      "dashboard_url": "https://www.deal.matsui.co.jp/",
       "has_xml": true,
       "マイナ連携": false,
       "collection": "auto",
@@ -115,7 +126,9 @@
       "has_xml": false,
       "マイナ連携": true,
       "collection": "auto",
-      "login_detection": { "custom": true }
+      "login_detection": {
+        "custom": true
+      }
     },
     {
       "code": "tsumiki",
@@ -127,15 +140,17 @@
       "has_xml": false,
       "マイナ連携": false,
       "collection": "auto",
-      "login_detection": { "custom": true }
+      "login_detection": {
+        "custom": true
+      }
     },
     {
       "code": "daiwa-connect",
       "name": "大和CONNECT証券",
       "document_type": "特定口座年間取引報告書",
       "site_url": "https://www.connect-sec.co.jp/",
-      "login_url": "https://www.connect-sec.co.jp/service/login/",
-      "dashboard_url": null,
+      "login_url": "https://www.connect-sec.co.jp/jumppages/login.html",
+      "dashboard_url": "https://trade.connect-sec.co.jp/webbroker3/Web3App",
       "has_xml": false,
       "マイナ連携": false,
       "collection": "auto",
@@ -154,19 +169,9 @@
       "has_xml": false,
       "マイナ連携": false,
       "collection": "auto",
-      "login_detection": { "custom": true }
-    },
-    {
-      "code": "webull",
-      "name": "ウィブル証券",
-      "document_type": "特定口座年間取引報告書",
-      "site_url": null,
-      "login_url": null,
-      "dashboard_url": null,
-      "has_xml": false,
-      "マイナ連携": false,
-      "collection": "android",
-      "login_detection": null
+      "login_detection": {
+        "custom": true
+      }
     },
     {
       "code": "nomura-mochikabu",
@@ -193,7 +198,9 @@
       "has_xml": false,
       "マイナ連携": false,
       "collection": "auto",
-      "login_detection": { "custom": true }
+      "login_detection": {
+        "custom": true
+      }
     },
     {
       "code": "sawakami",
@@ -205,7 +212,9 @@
       "has_xml": false,
       "マイナ連携": false,
       "collection": "auto",
-      "login_detection": { "custom": true }
+      "login_detection": {
+        "custom": true
+      }
     }
   ]
 }

--- a/skills/tax-collect/registry.json
+++ b/skills/tax-collect/registry.json
@@ -1,19 +1,211 @@
 {
   "securities": [
-    { "code": "sbi",              "name": "SBI証券",              "document_type": "特定口座年間取引報告書", "site_url": "https://www.sbisec.co.jp/",                        "login_url": "https://www.sbisec.co.jp/ETGate",                                      "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
-    { "code": "rakuten",          "name": "楽天証券",              "document_type": "特定口座年間取引報告書", "site_url": "https://www.rakuten-sec.co.jp/",                   "login_url": "https://www.rakuten-sec.co.jp/",                                        "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
-    { "code": "nomura",           "name": "野村證券",              "document_type": "特定口座年間取引報告書", "site_url": "https://www.nomura.co.jp/",                        "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",              "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
-    { "code": "monex",            "name": "マネックス証券",        "document_type": "特定口座年間取引報告書", "site_url": "https://www.monex.co.jp/",                         "login_url": "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp",             "has_xml": true,  "マイナ連携": true,  "collection": "auto"   },
-    { "code": "matsui",           "name": "松井証券",              "document_type": "特定口座年間取引報告書", "site_url": "https://www.matsui.co.jp/",                        "login_url": "https://www.matsui.co.jp/",                                             "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
-    { "code": "gmo-click",        "name": "GMOクリック証券",       "document_type": "特定口座年間取引報告書", "site_url": "https://www.click-sec.com/",                       "login_url": "https://kabu.click-sec.com/sec2/mypage/top.do",                        "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
-    { "code": "smbcnikko",        "name": "SMBC日興証券",          "document_type": "特定口座年間取引報告書", "site_url": "https://www.smbcnikko.co.jp/",                     "login_url": "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/",          "has_xml": true,  "マイナ連携": false, "collection": "auto"   },
-    { "code": "mufg-esmart",      "name": "三菱UFJ eスマート証券", "document_type": "特定口座年間取引報告書", "site_url": "https://kabu.com/",                                "login_url": null,                                                                    "has_xml": false, "マイナ連携": true,  "collection": "auto"   },
-    { "code": "tsumiki",          "name": "tsumiki証券",           "document_type": "特定口座年間取引報告書", "site_url": "https://www.tsumiki-sec.com/",                     "login_url": null,                                                                    "has_xml": false, "マイナ連携": false, "collection": "auto"   },
-    { "code": "daiwa-connect",    "name": "大和CONNECT証券",       "document_type": "特定口座年間取引報告書", "site_url": "https://www.connect-sec.co.jp/",                   "login_url": "https://www.connect-sec.co.jp/service/login/",                         "has_xml": false, "マイナ連携": false, "collection": "auto"   },
-    { "code": "paypay",           "name": "PayPay証券",            "document_type": "特定口座年間取引報告書", "site_url": "https://www.paypay-sec.co.jp/",                    "login_url": null,                                                                    "has_xml": false, "マイナ連携": false, "collection": "auto"   },
-    { "code": "webull",           "name": "ウィブル証券",          "document_type": "特定口座年間取引報告書", "site_url": null,                                               "login_url": null,                                                                    "has_xml": false, "マイナ連携": false, "collection": "android" },
-    { "code": "nomura-mochikabu", "name": "野村證券持株会",        "document_type": "配当金等支払通知書",     "site_url": "https://www.e-plan.nomura.co.jp/",                 "login_url": "https://www.e-plan.nomura.co.jp/login/index.html",                     "has_xml": false, "マイナ連携": false, "collection": "auto"   },
-    { "code": "hifumi",           "name": "ひふみ投信",            "document_type": "特定口座年間取引報告書", "site_url": "https://hifumi.rheos.jp/",                         "login_url": null,                                                                    "has_xml": false, "マイナ連携": false, "collection": "auto"   },
-    { "code": "sawakami",         "name": "さわかみ投信",          "document_type": "特定口座年間取引報告書", "site_url": "https://fv.sawakami.co.jp/",                       "login_url": "https://fv.sawakami.co.jp/Account/Login",                              "has_xml": false, "マイナ連携": false, "collection": "auto"   }
+    {
+      "code": "sbi",
+      "name": "SBI証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.sbisec.co.jp/",
+      "login_url": "https://www.sbisec.co.jp/ETGate",
+      "dashboard_url": "https://www.sbisec.co.jp/ETGate/",
+      "has_xml": true,
+      "マイナ連携": true,
+      "collection": "auto",
+      "login_detection": {
+        "done_url": "**/ETGate/**",
+        "skip_selector_absent": "input[name='username']"
+      }
+    },
+    {
+      "code": "rakuten",
+      "name": "楽天証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.rakuten-sec.co.jp/",
+      "login_url": "https://www.rakuten-sec.co.jp/",
+      "dashboard_url": "https://www.rakuten-sec.co.jp/",
+      "has_xml": true,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "done_selector": "button[aria-label*='マイメニュー']",
+        "skip_selector": "button[aria-label*='マイメニュー']"
+      }
+    },
+    {
+      "code": "nomura",
+      "name": "野村證券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.nomura.co.jp/",
+      "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",
+      "dashboard_url": "https://hometrade.nomura.co.jp/web/",
+      "has_xml": true,
+      "マイナ連携": true,
+      "collection": "auto",
+      "login_detection": {
+        "skip_url_contains": "hometrade.nomura.co.jp",
+        "skip_url_excludes": "login"
+      }
+    },
+    {
+      "code": "monex",
+      "name": "マネックス証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.monex.co.jp/",
+      "login_url": "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp",
+      "dashboard_url": "https://mst.monex.co.jp/",
+      "has_xml": true,
+      "マイナ連携": true,
+      "collection": "auto",
+      "login_detection": {
+        "skip_url_contains": "mst.monex.co.jp",
+        "skip_url_excludes": "LoginIDPassword"
+      }
+    },
+    {
+      "code": "matsui",
+      "name": "松井証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.matsui.co.jp/",
+      "login_url": "https://www.matsui.co.jp/",
+      "dashboard_url": "https://www.matsui.co.jp/",
+      "has_xml": true,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "done_selector": "frame[name='GM']",
+        "skip_selector": "frame[name='GM']"
+      }
+    },
+    {
+      "code": "gmo-click",
+      "name": "GMOクリック証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.click-sec.com/",
+      "login_url": "https://kabu.click-sec.com/sec2/mypage/top.do",
+      "dashboard_url": "https://kabu.click-sec.com/sec2/mypage/top.do",
+      "has_xml": true,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "done_url": "**/mypage/top**",
+        "skip_url_contains": "mypage/top"
+      }
+    },
+    {
+      "code": "smbcnikko",
+      "name": "SMBC日興証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.smbcnikko.co.jp/",
+      "login_url": "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/",
+      "dashboard_url": "https://trade.smbcnikko.co.jp/",
+      "has_xml": true,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "skip_url_contains": "trade.smbcnikko.co.jp",
+        "skip_url_excludes": "/Login/0/login/"
+      }
+    },
+    {
+      "code": "mufg-esmart",
+      "name": "三菱UFJ eスマート証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://kabu.com/",
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": true,
+      "collection": "auto",
+      "login_detection": { "custom": true }
+    },
+    {
+      "code": "tsumiki",
+      "name": "tsumiki証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.tsumiki-sec.com/",
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": { "custom": true }
+    },
+    {
+      "code": "daiwa-connect",
+      "name": "大和CONNECT証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.connect-sec.co.jp/",
+      "login_url": "https://www.connect-sec.co.jp/service/login/",
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "done_url": "**/webbroker3/**",
+        "skip_url_contains": "webbroker3"
+      }
+    },
+    {
+      "code": "paypay",
+      "name": "PayPay証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.paypay-sec.co.jp/",
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": { "custom": true }
+    },
+    {
+      "code": "webull",
+      "name": "ウィブル証券",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": null,
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "android",
+      "login_detection": null
+    },
+    {
+      "code": "nomura-mochikabu",
+      "name": "野村證券持株会",
+      "document_type": "配当金等支払通知書",
+      "site_url": "https://www.e-plan.nomura.co.jp/",
+      "login_url": "https://www.e-plan.nomura.co.jp/login/index.html",
+      "dashboard_url": "https://www.e-plan.nomura.co.jp/",
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "skip_url_contains": "e-plan.nomura.co.jp",
+        "skip_url_excludes": "login"
+      }
+    },
+    {
+      "code": "hifumi",
+      "name": "ひふみ投信",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://hifumi.rheos.jp/",
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": { "custom": true }
+    },
+    {
+      "code": "sawakami",
+      "name": "さわかみ投信",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://fv.sawakami.co.jp/",
+      "login_url": "https://fv.sawakami.co.jp/Account/Login",
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": { "custom": true }
+    }
   ]
 }

--- a/skills/tax-collect/run.py
+++ b/skills/tax-collect/run.py
@@ -79,15 +79,15 @@ def run_site(code: str, name: str, year: int) -> Literal["ok", "error", "missing
 
 def _prompt_android(code: str, name: str) -> bool:
     """Enterで実行、s で スキップ。非対話(EOF)はスキップ側。戻り: True=実行, False=スキップ"""
-    _print_header(f"[{code}] {name} — Android収集")
+    _print_header(f"[{code}] {name} - Android収集")
     print("  1. デバイスをUSBで接続")
     print("  2. USBデバッグを有効化（開発者オプション）")
     print("\nEnterで収集開始、Sキー+Enterでスキップ: ", end="", flush=True)
     try:
         ans = input().strip().lower()
     except EOFError:
-        print("\n[非対話実行] スキップ")
-        return False
+        print("\n[非対話実行] 実行")
+        return True
     return ans != "s"
 
 
@@ -173,8 +173,30 @@ def main() -> None:
     print(f"  SKIP    : {', '.join(results['skip']) or 'なし'}  ← 手動/未対応")
     print(f"{'='*60}")
 
+    _report_pdf_queue()
+
     if results["error"] or results["missing"]:
         sys.exit(1)
+
+
+def _report_pdf_queue() -> None:
+    """PDF→JSON変換キューの登録件数を表示。実変換は convert.py で行う。"""
+    queue_dir = _PROJECT_ROOT / "output" / "converting"
+    if not queue_dir.exists():
+        return
+    queues = sorted(queue_dir.glob("*.queue"))
+    err_queues = sorted(queue_dir.glob("*.queue.err"))
+    if not queues and not err_queues:
+        return
+    if queues:
+        print(f"\n[QUEUE] PDF→JSON変換キュー: {len(queues)}件")
+        for p in queues:
+            print(f"  - {p.stem}")
+    if err_queues:
+        print(f"\n[QUEUE] 前回失敗キュー: {len(err_queues)}件（.queue にリネームで再実行可）")
+        for p in err_queues:
+            print(f"  - {p.name}")
+    print(f"[QUEUE] 変換実行: python skills/tax-collect/convert.py --year <YEAR>")
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -29,11 +29,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
-import sys
 from pathlib import Path
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
@@ -41,9 +37,7 @@ from money_ops.converter.pdf_to_json import convert_pdf_to_json
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.connect-sec.co.jp/service/login/"
 
-
 from money_ops.utils import wait as _wait
-
 
 class DaiwaConnectCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -250,15 +244,12 @@ class DaiwaConnectCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="大和コネクト証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = DaiwaConnectCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -10,8 +10,8 @@
     DAIWACONNECT_PASS   ログインパスワード（未設定時は手動入力）
 
 注意:
-    ログイン後の2段階認証コードは必ず手動入力が必要。
-    コード入力後 Enter を押すこと。
+    ログイン後の2段階認証コードはブラウザで直接入力・送信してください。
+    スクリプトはブラウザの状態変化を自動検出します。
 
 実測済みページ構造:
     page:  connect-sec.co.jp/service/login/（トップ）
@@ -80,14 +80,11 @@ class DaiwaConnectCollector(BaseCollector):
             self.save_html(page1, "after_login1")
             # 2段階認証コード（自動ログイン時のみ）
             if "webbroker3" not in page1.url:
-                print(f"[{self.name}] 2段階認証コードを入力してください（メールに届いた6桁）")
-                code = self.prompt("認証コード: ").strip()
-                page1.get_by_role("textbox").first.fill(code)
-                page1.get_by_role("link", name=re.compile("ログイン")).first.click()
-                _wait(2.0, 3.0)
+                print(f"[{self.name}] 2段階認証コードをブラウザに入力して送信してください（最大5分）")
+                page1.wait_for_url("**/webbroker3/**", timeout=300_000)
         else:
-            print(f"[{self.name}] ログインしてください（メールアドレス・パスワード・2段階認証まですべて完了後 Enter）")
-            self.prompt("完了後 Enter: ")
+            print(f"[{self.name}] ログインしてください（メールアドレス・パスワード・2段階認証まですべて完了）（最大5分）")
+            page1.wait_for_url("**/webbroker3/**", timeout=300_000)
 
         # webbroker3 SPA の読み込み完了を待つ
         page1.wait_for_url("**/webbroker3/**", timeout=30000)

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -29,10 +29,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -45,8 +43,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.connect-sec.co.jp/service/login/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class DaiwaConnectCollector(BaseCollector):

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -39,8 +39,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 from money_ops.utils import wait as _wait
 
 class DaiwaConnectCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _login(self, page) -> object:
         """connect-sec.co.jp → jumppages/login.html → 認証 → webbroker3。
@@ -246,8 +246,10 @@ class DaiwaConnectCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="大和コネクト証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = DaiwaConnectCollector(year=args.year)
+    collector = DaiwaConnectCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -47,11 +47,7 @@ from money_ops.utils import wait as _wait
 
 class DaiwaConnectCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/daiwa-connect/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _login(self, page) -> object:
         """connect-sec.co.jp → jumppages/login.html → 認証 → webbroker3。

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -228,43 +228,32 @@ class DaiwaConnectCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
+    def _collect_core(self, page) -> None:
+        page1 = self._login(page)
+        year = self.config["target_year"]
+
+        page2 = self._open_electronic_delivery(page1)
+        self._navigate_to_annual_report(page2)
+
+        pdf_path = self._download_pdf_via_route(page2, year)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 捕捉失敗")
+            return
+
         try:
-            page1 = self._login(page)
-            year = self.config["target_year"]
-
-            page2 = self._open_electronic_delivery(page1)
-            self._navigate_to_annual_report(page2)
-
-            pdf_path = self._download_pdf_via_route(page2, year)
-            if pdf_path is None:
-                self.log_result("error", [], "PDF 捕捉失敗")
-                return
-
-            try:
-                data = convert_pdf_to_json(
-                    pdf_path=pdf_path,
-                    company=self.name,
-                    code=self.code,
-                    year=year,
-                    raw_files=[str(Path(pdf_path).name)],
-                )
-                self._write_report_json(data)
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ: {e}")
-
-            self.log_result("success", [pdf_path])
-
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
+            data = convert_pdf_to_json(
+                pdf_path=pdf_path,
+                company=self.name,
+                code=self.code,
+                year=year,
+                raw_files=[str(Path(pdf_path).name)],
+            )
+            self._write_report_json(data)
         except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
+            print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+        self.log_result("success", [pdf_path])
+
 
 
 def main() -> None:
@@ -272,7 +261,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = DaiwaConnectCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -27,6 +27,7 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
+import sys
 import os
 import re
 from pathlib import Path
@@ -231,7 +232,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = DaiwaConnectCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -35,7 +35,6 @@ from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://www.connect-sec.co.jp/service/login/"
 
 from money_ops.utils import wait as _wait
 
@@ -52,7 +51,7 @@ class DaiwaConnectCollector(BaseCollector):
           - セッション有効時 → jumppages が webbroker3 へ即リダイレクト（ログインスキップ）
           - セッション無効時 → メールアドレス + パスワード → ログイン → 2段階認証コード
         """
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -27,7 +27,6 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -251,10 +250,7 @@ class DaiwaConnectCollector(BaseCollector):
                     year=year,
                     raw_files=[str(Path(pdf_path).name)],
                 )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
+                self._write_report_json(data)
             except Exception as e:
                 print(f"[{self.name}] JSON 変換スキップ: {e}")
 

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -32,7 +32,6 @@ import re
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 
@@ -52,11 +51,6 @@ class DaiwaConnectCollector(BaseCollector):
           - セッション無効時 → メールアドレス + パスワード → ログイン → 2段階認証コード
         """
         page.goto(self.config["login_url"])
-        page.wait_for_load_state("domcontentloaded")
-        _wait(1.5, 2.5)
-
-        # Chromium で popup が読み込めないため同一ページで直接遷移
-        page.goto("https://www.connect-sec.co.jp/jumppages/login.html")
         page1 = page
         page1.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
@@ -105,7 +99,8 @@ class DaiwaConnectCollector(BaseCollector):
         """
         print(f"[{self.name}] お客様情報 → 電子交付サービスへ移動")
         # sidrToggle（モバイル用不可視）を除外して本体ナビをクリック
-        page1.locator("ul.navbar-nav a:not(.sidrToggle)", has_text="お客様情報").click()
+        page1.locator("ul.navbar-nav a:not(.sidrToggle)").filter(has_text="お客様情報").first.wait_for(state="visible", timeout=60_000)
+        page1.locator("ul.navbar-nav a:not(.sidrToggle)").filter(has_text="お客様情報").first.click()
         page1.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 
@@ -226,18 +221,7 @@ class DaiwaConnectCollector(BaseCollector):
             self.log_result("error", [], "PDF 捕捉失敗")
             return
 
-        try:
-            data = convert_pdf_to_json(
-                pdf_path=pdf_path,
-                company=self.name,
-                code=self.code,
-                year=year,
-                raw_files=[str(Path(pdf_path).name)],
-            )
-            self._write_report_json(data)
-        except Exception as e:
-            print(f"[{self.name}] JSON 変換スキップ: {e}")
-
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
         self.log_result("success", [pdf_path])
 
 def main() -> None:

--- a/skills/tax-collect/sites/daiwa-connect/collect.py
+++ b/skills/tax-collect/sites/daiwa-connect/collect.py
@@ -81,13 +81,13 @@ class DaiwaConnectCollector(BaseCollector):
             # 2段階認証コード（自動ログイン時のみ）
             if "webbroker3" not in page1.url:
                 print(f"[{self.name}] 2段階認証コードを入力してください（メールに届いた6桁）")
-                code = input("認証コード: ").strip()
+                code = self.prompt("認証コード: ").strip()
                 page1.get_by_role("textbox").first.fill(code)
                 page1.get_by_role("link", name=re.compile("ログイン")).first.click()
                 _wait(2.0, 3.0)
         else:
             print(f"[{self.name}] ログインしてください（メールアドレス・パスワード・2段階認証まですべて完了後 Enter）")
-            input("完了後 Enter: ")
+            self.prompt("完了後 Enter: ")
 
         # webbroker3 SPA の読み込み完了を待つ
         page1.wait_for_url("**/webbroker3/**", timeout=30000)

--- a/skills/tax-collect/sites/daiwa-connect/site.json
+++ b/skills/tax-collect/sites/daiwa-connect/site.json
@@ -8,6 +8,6 @@
       "type": "特定口座年間取引報告書"
     }
   ],
-  "login_url": "https://www.connect-sec.co.jp/service/login/",
+  "login_url": "https://www.connect-sec.co.jp/jumppages/login.html",
   "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/daiwa-connect/site.json
+++ b/skills/tax-collect/sites/daiwa-connect/site.json
@@ -1,10 +1,13 @@
 {
   "name": "大和コネクト証券",
   "code": "daiwa-connect",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/daiwa-connect/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.connect-sec.co.jp/service/login/",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -75,15 +75,26 @@ class GMOClickCollector(BaseCollector):
         _wait()
         session.get_by_role("link", name="電子書類閲覧").click()
         _wait()
-        with session.expect_popup() as popup_info:
-            session.locator("#stockReportLink").click()
-            _wait(2.0, 3.0)
-            # 2FAモーダルが表示された場合のみ処理（セッション状態によって有無が変わる）
-            if session.locator("#appTwoStepVerificationCode").is_visible():
-                print(f"[{self.name}] アプリ2FAコードを入力してください（認証ボタンはスクリプトが押します）")
-                input("コード入力後 Enter を押してください: ")
+        session.locator("#stockReportLink").click()
+        _wait(2.0, 3.0)
+        # 2FAモーダルが表示された場合のみ処理（セッション状態によって有無が変わる）
+        if session.locator("#appTwoStepVerificationCode").is_visible():
+            print(f"[{self.name}] アプリ2FAコードを入力してください（認証ボタンはスクリプトが押します）")
+            input("コード入力後 Enter を押してください: ")
+            with session.expect_popup() as popup_info:
                 session.locator("#btnConfirm").click()
-        popup = popup_info.value
+            popup = popup_info.value
+        else:
+            # 2FAなし: #stockReportLink クリックでポップアップが開く（遅延考慮でリトライ）
+            popup = None
+            for _ in range(6):
+                new_pages = [p for p in session.context.pages if p is not session]
+                if new_pages:
+                    popup = new_pages[-1]
+                    break
+                _wait(0.5, 1.0)
+            if popup is None:
+                raise RuntimeError(f"[{self.name}] ポップアップが開きませんでした")
         popup.wait_for_load_state("domcontentloaded")
         # e-shishobako Angular SPA: SSO後のルーティング完了を待つ（SBIと同方式）
         popup.wait_for_url("**/dp_apl/usr/**", timeout=30000)

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -17,10 +17,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
@@ -35,8 +33,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://kabu.click-sec.com/sec2/mypage/top.do"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -59,11 +59,15 @@ class GMOClickCollector(BaseCollector):
         if isinstance(url, str) and "mypage/top" in url:
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             self._session = page
+            self.dlog(f"URL: {page.url}")
+            self.save_html(page, "after_login_skip")
             return
         print(f"[{self.name}] ブラウザでログインしてください")
         input("ログイン完了後 Enter を押してください: ")
         _wait()
         self._session = page
+        self.dlog(f"URL: {page.url}")
+        self.save_html(page, "after_login")
         # セッション状態（cookie含む）を保存
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))
         print(f"[{self.name}] セッション状態を保存しました")
@@ -106,6 +110,8 @@ class GMOClickCollector(BaseCollector):
         popup.wait_for_url("**/dp_apl/usr/**", timeout=30000)
         popup.wait_for_selector("input, button", timeout=30000)
         _wait(2.0, 3.0)
+        self.dlog(f"popup URL: {popup.url}")
+        self.save_html(popup, "report_popup")
         return popup
 
     def _find_report_row_button(self, popup, target_year: int):

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://kabu.click-sec.com/sec2/mypage/top.do"
 
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
@@ -35,7 +34,7 @@ class GMOClickCollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         url = page.url
         if isinstance(url, str) and "mypage/top" in url:

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -167,29 +167,18 @@ class GMOClickCollector(BaseCollector):
 
         return downloaded
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            popup = self._navigate_to_report_popup()
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        popup = self._navigate_to_report_popup()
 
-            downloaded = self._download_files(popup)
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        downloaded = self._download_files(popup)
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -197,7 +186,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = GMOClickCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 
@@ -25,7 +24,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://kabu.click-sec.com/sec2/mypage/top.do"
@@ -169,25 +167,6 @@ class GMOClickCollector(BaseCollector):
 
         return downloaded
 
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -199,7 +178,7 @@ class GMOClickCollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -31,7 +31,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://kabu.click-sec.com/sec2/mypage/top.do"
 
 
-from money_ops.utils import extract_filename, wait as _wait
+from money_ops.collector.eshishobako import capture_dpaw_pdf
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:
@@ -118,47 +119,6 @@ class GMOClickCollector(BaseCollector):
                 return btn.first
         return None
 
-    def _download_pdf_via_route(self, popup, output_dir: Path, fallback_name: str) -> str | None:
-        """context.route() で DPAW010501020 の PDF レスポンスを捕捉して保存
-        PDF ボタンクリック → blob URL ポップアップが開く → 閉じてから unroute（SBIと同方式）"""
-        pdf_btn = popup.locator("button, a").filter(has_text="PDFファイル")
-        if pdf_btn.count() == 0:
-            print(f"[{self.name}] PDF ボタンが見つかりません")
-            return None
-
-        pdf_bytes_holder: list[tuple[str, bytes]] = []
-
-        def _capture_pdf(route, _request) -> None:
-            response = route.fetch()
-            body = response.body()
-            if body[:4] == b"%PDF":
-                cd = response.headers.get("content-disposition", "")
-                m = _RE_FILENAME.search(cd)
-                filename = m.group(1).strip().strip('"\'') if m else fallback_name
-                pdf_bytes_holder.append((filename, body))
-            route.fulfill(response=response)
-
-        popup.context.route("**/DPAW010501020", _capture_pdf)
-        try:
-            with popup.expect_popup() as pdf_popup_info:
-                pdf_btn.first.click()
-            pdf_popup = pdf_popup_info.value
-            pdf_popup.wait_for_load_state("domcontentloaded")
-            _wait()
-            pdf_popup.close()
-        finally:
-            popup.context.unroute("**/DPAW010501020", _capture_pdf)
-
-        if not pdf_bytes_holder:
-            print(f"[{self.name}] PDF レスポンスを捕捉できませんでした")
-            return None
-
-        filename, pdf_bytes = pdf_bytes_holder[0]
-        pdf_path = output_dir / filename
-        pdf_path.write_bytes(pdf_bytes)
-        print(f"[{self.name}] PDF 保存: {pdf_path}")
-        return str(pdf_path)
-
     def _download_files(self, popup) -> list[str]:
         self.prepare_directory()
         year = self.config["target_year"]
@@ -199,9 +159,9 @@ class GMOClickCollector(BaseCollector):
         else:
             print(f"[{self.name}] XML ボタンが見つかりません")
 
-        # PDF（e-shishobako DPAW010501020 ルート捕捉。SBIと完全同方式）
-        pdf_path = self._download_pdf_via_route(
-            popup, self.output_dir, f"{year}_nentori.pdf"
+        # PDF（e-shishobako DPAW010501020 ルート捕捉）
+        pdf_path = capture_dpaw_pdf(
+            popup, self.output_dir, f"{year}_nentori.pdf", label=self.name
         )
         if pdf_path:
             downloaded.append(pdf_path)

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -44,7 +44,7 @@ class GMOClickCollector(BaseCollector):
             self.save_html(page, "after_login_skip")
             return
         print(f"[{self.name}] ブラウザでログインしてください")
-        input("ログイン完了後 Enter を押してください: ")
+        self.prompt("ログイン完了後 Enter を押してください: ")
         _wait()
         self._session = page
         self.dlog(f"URL: {page.url}")
@@ -71,7 +71,7 @@ class GMOClickCollector(BaseCollector):
         # 2FAモーダルが表示された場合のみ処理（セッション状態によって有無が変わる）
         if session.locator("#appTwoStepVerificationCode").is_visible():
             print(f"[{self.name}] アプリ2FAコードを入力してください（認証ボタンはスクリプトが押します）")
-            input("コード入力後 Enter を押してください: ")
+            self.prompt("コード入力後 Enter を押してください: ")
             with session.expect_popup() as popup_info:
                 session.locator("#btnConfirm").click()
             popup = popup_info.value

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -40,11 +40,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class GMOClickCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/gmo-click/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -54,6 +54,12 @@ class GMOClickCollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)
+        page.wait_for_load_state("domcontentloaded")
+        url = page.url
+        if isinstance(url, str) and "mypage/top" in url:
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self._session = page
+            return
         print(f"[{self.name}] ブラウザでログインしてください")
         input("ログイン完了後 Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -17,11 +17,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -33,7 +31,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://kabu.click-sec.com/sec2/mypage/top.do"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
@@ -169,7 +170,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = GMOClickCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -30,8 +30,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}/12", f"{target_year + 1}/01"]
 
 class GMOClickCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -169,8 +169,10 @@ class GMOClickCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="GMOクリック証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = GMOClickCollector(year=args.year)
+    collector = GMOClickCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -16,27 +16,19 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://kabu.click-sec.com/sec2/mypage/top.do"
 
-
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
-
 
 def _year_month_patterns(target_year: int) -> list[str]:
     """発行年月の候補: 対象年12月 or 翌年1月"""
     return [f"{target_year}/12", f"{target_year + 1}/01"]
-
 
 class GMOClickCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -175,15 +167,12 @@ class GMOClickCollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="GMOクリック証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = GMOClickCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/gmo-click/collect.py
+++ b/skills/tax-collect/sites/gmo-click/collect.py
@@ -43,9 +43,8 @@ class GMOClickCollector(BaseCollector):
             self.dlog(f"URL: {page.url}")
             self.save_html(page, "after_login_skip")
             return
-        print(f"[{self.name}] ブラウザでログインしてください")
-        self.prompt("ログイン完了後 Enter を押してください: ")
-        _wait()
+        print(f"[{self.name}] ブラウザでログインしてください（最大5分）")
+        page.wait_for_url("**/mypage/top**", timeout=300_000)
         self._session = page
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")
@@ -70,11 +69,8 @@ class GMOClickCollector(BaseCollector):
         _wait(2.0, 3.0)
         # 2FAモーダルが表示された場合のみ処理（セッション状態によって有無が変わる）
         if session.locator("#appTwoStepVerificationCode").is_visible():
-            print(f"[{self.name}] アプリ2FAコードを入力してください（認証ボタンはスクリプトが押します）")
-            self.prompt("コード入力後 Enter を押してください: ")
-            with session.expect_popup() as popup_info:
-                session.locator("#btnConfirm").click()
-            popup = popup_info.value
+            print(f"[{self.name}] 2FAコードを入力して「認証する」ボタンを押してください（最大5分）")
+            popup = session.wait_for_event("popup", timeout=300_000)
         else:
             # 2FAなし: #stockReportLink クリックでポップアップが開く（遅延考慮でリトライ）
             popup = None

--- a/skills/tax-collect/sites/gmo-click/site.json
+++ b/skills/tax-collect/sites/gmo-click/site.json
@@ -1,10 +1,13 @@
 {
   "name": "GMOクリック証券",
   "code": "gmo-click",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/gmo-click/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://kabu.click-sec.com/sec2/mypage/top.do",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -31,7 +31,6 @@ import re
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 
@@ -68,7 +67,9 @@ class HifumiCollector(BaseCollector):
         self.dlog(f"page1 URL: {page1.url}")
 
         print(f"[{self.name}] page1 でログインしてください（loginId・パスワード・取引パスワード）（最大5分）")
-        page1.wait_for_selector("a:has-text('各種資料')", timeout=300_000)
+        # login.jsp → login.do への URL 変化でダッシュボード到達を検出
+        # a:has-text('残高照会') は DOM に複数存在し visible=false のため使用不可
+        page1.wait_for_url("**/wsys/login.do**", timeout=300_000)
         _wait(2.0, 3.0)
 
         # session cookie 明示保存（persistent profile だけでは session cookie が消える）
@@ -88,13 +89,19 @@ class HifumiCollector(BaseCollector):
           - page2 = popup（最終的に post.plus.e-shishobako.ne.jp/dp_apl/usr/#/user-delivery）
         """
         print(f"[{self.name}] 各種資料（報告書）へ移動")
-        page1.get_by_role("link", name="各種資料（報告書）").click()
-        page1.wait_for_load_state("domcontentloaded")
-        _wait(1.5, 2.5)
-        self.save_html(page1, "after_kakushu_shiryo")
-
-        with page1.expect_popup() as popup2_info:
-            page1.get_by_role("link", name="閲覧する").nth(1).click()
+        kakushu = page1.get_by_role("link", name="各種資料（報告書）")
+        if kakushu.count() > 0:
+            kakushu.first.click()
+            page1.wait_for_load_state("domcontentloaded")
+            _wait(1.5, 2.5)
+            self.save_html(page1, "after_kakushu_shiryo")
+            with page1.expect_popup() as popup2_info:
+                page1.get_by_role("link", name="閲覧する").nth(1).click()
+        else:
+            # 各種資料リンクが見つからない場合は shishyobakoRedirect へ直接
+            print(f"[{self.name}] 各種資料リンク未検出 → shishyobakoRedirect を直接クリック")
+            with page1.expect_popup() as popup2_info:
+                page1.locator("a[href*='shishyobakoRedirect']").first.click()
         page2 = popup2_info.value
 
         # shishyobakoRedirect.do → e-shishobako Angular SPA へのリダイレクト完了待機
@@ -174,18 +181,7 @@ class HifumiCollector(BaseCollector):
             self.log_result("error", [], "PDF 捕捉失敗")
             return
 
-        try:
-            data = convert_pdf_to_json(
-                pdf_path=pdf_path,
-                company=self.name,
-                code=self.code,
-                year=year,
-                raw_files=[str(Path(pdf_path).name)],
-            )
-            self._write_report_json(data)
-        except Exception as e:
-            print(f"[{self.name}] JSON 変換スキップ（ANTHROPIC_API_KEY 未設定等）: {e}")
-
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
         self.log_result("success", [pdf_path])
 
 def main() -> None:

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -28,12 +28,7 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
@@ -41,14 +36,11 @@ from money_ops.converter.pdf_to_json import convert_pdf_to_json
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hifumi.rheos.jp/"
 
-
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
 
-
 def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}/12", f"{target_year + 1}/01"]
-
 
 class HifumiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -197,15 +189,12 @@ class HifumiCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="ひふみ投信 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = HifumiCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -43,7 +43,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hifumi.rheos.jp/"
 
 
-from money_ops.utils import extract_filename, wait as _wait
+from money_ops.collector.eshishobako import capture_dpaw_pdf
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:
@@ -164,52 +165,6 @@ class HifumiCollector(BaseCollector):
         _wait()
         return True
 
-    def _download_pdf_via_route(self, page2, target_year: int) -> str | None:
-        """「PDFファイル」ボタンクリック → DPAW010501020 route 捕捉 → blob popup 閉じる。
-        SBI と同じ e-shishobako ポータルのため完全同方式。
-        """
-        pdf_btn = page2.get_by_role("button").filter(has_text="PDFファイル")
-        if pdf_btn.count() == 0:
-            pdf_btn = page2.get_by_role("link").filter(has_text="PDFファイル")
-        if pdf_btn.count() == 0:
-            self.dlog("PDFファイル ボタンが見つかりません")
-            return None
-
-        pdf_bytes_holder: list[tuple[str, bytes]] = []
-        fallback_name = f"{target_year}_hifumi_nentori.pdf"
-
-        def _capture_pdf(route, _request) -> None:
-            response = route.fetch()
-            body = response.body()
-            if body[:4] == b"%PDF":
-                cd = response.headers.get("content-disposition", "")
-                m = _RE_FILENAME.search(cd)
-                filename = m.group(1).strip().strip('"\'') if m else fallback_name
-                pdf_bytes_holder.append((filename, body))
-            route.fulfill(response=response)
-
-        page2.context.route("**/DPAW010501020", _capture_pdf)
-        try:
-            with page2.expect_popup() as pdf_popup_info:
-                pdf_btn.first.click()
-            pdf_popup = pdf_popup_info.value
-            pdf_popup.wait_for_load_state("domcontentloaded")
-            _wait()
-            pdf_popup.close()
-        finally:
-            page2.context.unroute("**/DPAW010501020", _capture_pdf)
-
-        if not pdf_bytes_holder:
-            self.dlog("PDF レスポンスを捕捉できませんでした")
-            return None
-
-        self.prepare_directory()
-        filename, pdf_bytes = pdf_bytes_holder[0]
-        pdf_path = self.output_dir / filename
-        pdf_path.write_bytes(pdf_bytes)
-        print(f"[{self.name}] PDF 保存: {pdf_path}")
-        return str(pdf_path)
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -227,7 +182,10 @@ class HifumiCollector(BaseCollector):
                 self.log_result("skip", [], f"{year}年度の特定口座年間取引報告書ボタンが見つかりません")
                 return
 
-            pdf_path = self._download_pdf_via_route(page2, year)
+            self.prepare_directory()
+            pdf_path = capture_dpaw_pdf(
+                page2, self.output_dir, f"{year}_hifumi_nentori.pdf", label=self.name
+            )
             if pdf_path is None:
                 self.log_result("error", [], "PDF 捕捉失敗")
                 return

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -34,7 +34,6 @@ from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://hifumi.rheos.jp/"
 
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
@@ -52,7 +51,7 @@ class HifumiCollector(BaseCollector):
           - loginId + #password_01 → 「ログイン」→ 取引パスワード → 「認証」（すべて手動）
           - page1 URL はログイン後も login.jsp のまま（SPA）
         """
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -28,10 +28,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
@@ -46,8 +44,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hifumi.rheos.jp/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -52,11 +52,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class HifumiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/hifumi/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> object:
         """HAR 確認済み:

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -9,7 +9,7 @@
 
 注意:
     ログイン・取引パスワード入力は人間が手動で行う。
-    スクリプト起動後、ブラウザでポップアップ（page1）にてログイン完了後 Enter を押すこと。
+    スクリプト起動後、ブラウザでポップアップ（page1）にてログイン完了を自動検出します。
 
 実測済みポップアップ構造:
     page:  ひふみ トップ（hifumi.rheos.jp）
@@ -67,8 +67,8 @@ class HifumiCollector(BaseCollector):
         _wait(1.5, 2.5)
         self.dlog(f"page1 URL: {page1.url}")
 
-        print(f"[{self.name}] page1 でログインしてください（loginId・パスワード・取引パスワード）")
-        self.prompt("ログイン完了後 Enter を押してください: ")
+        print(f"[{self.name}] page1 でログインしてください（loginId・パスワード・取引パスワード）（最大5分）")
+        page1.wait_for_selector("a:has-text('各種資料')", timeout=300_000)
         _wait(2.0, 3.0)
 
         # session cookie 明示保存（persistent profile だけでは session cookie が消える）

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -68,7 +68,7 @@ class HifumiCollector(BaseCollector):
         self.dlog(f"page1 URL: {page1.url}")
 
         print(f"[{self.name}] page1 でログインしてください（loginId・パスワード・取引パスワード）")
-        input("ログイン完了後 Enter を押してください: ")
+        self.prompt("ログイン完了後 Enter を押してください: ")
         _wait(2.0, 3.0)
 
         # session cookie 明示保存（persistent profile だけでは session cookie が消える）

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -27,6 +27,7 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
+import sys
 import re
 from pathlib import Path
 
@@ -67,9 +68,10 @@ class HifumiCollector(BaseCollector):
         self.dlog(f"page1 URL: {page1.url}")
 
         print(f"[{self.name}] page1 でログインしてください（loginId・パスワード・取引パスワード）（最大5分）")
-        # login.jsp → login.do への URL 変化でダッシュボード到達を検出
-        # a:has-text('残高照会') は DOM に複数存在し visible=false のため使用不可
-        page1.wait_for_url("**/wsys/login.do**", timeout=300_000)
+        # ダッシュボード描画完了を「各種資料（報告書）」link visible で検出（5分タイムアウト）。
+        # URL 変化（login.jsp→login.do）はセッション cookie 残存時に手動入力前に発火して
+        # しまう（=login.do に自動遷移しても再ログイン画面の場合あり）→ URL 待機は使わない。
+        page1.get_by_role("link", name="各種資料（報告書）").first.wait_for(state="visible", timeout=300_000)
         _wait(2.0, 3.0)
 
         # session cookie 明示保存（persistent profile だけでは session cookie が消える）
@@ -95,17 +97,19 @@ class HifumiCollector(BaseCollector):
             page1.wait_for_load_state("domcontentloaded")
             _wait(1.5, 2.5)
             self.save_html(page1, "after_kakushu_shiryo")
-            with page1.expect_popup() as popup2_info:
-                page1.get_by_role("link", name="閲覧する").nth(1).click()
         else:
-            # 各種資料リンクが見つからない場合は shishyobakoRedirect へ直接
-            print(f"[{self.name}] 各種資料リンク未検出 → shishyobakoRedirect を直接クリック")
-            with page1.expect_popup() as popup2_info:
-                page1.locator("a[href*='shishyobakoRedirect']").first.click()
+            print(f"[{self.name}] 各種資料リンク未検出 → 直接 shishyobakoRedirect を試行")
+
+        # 「閲覧する」は nth(1) で順序依存 → href ロケートに統一
+        # （HAR 確認: target="_blank" rel="noopener" で popup 開く設計）
+        shishobako_link = page1.locator("a[href*='shishyobakoRedirect']")
+        shishobako_link.first.wait_for(state="visible", timeout=15000)
+        with page1.expect_popup() as popup2_info:
+            shishobako_link.first.click()
         page2 = popup2_info.value
 
-        # shishyobakoRedirect.do → e-shishobako Angular SPA へのリダイレクト完了待機
-        page2.wait_for_url("**/dp_apl/usr/**", timeout=30000)
+        # 4段リダイレクト（shishyobakoRedirect → SSO → DPAW010501000 → /dp_apl/usr/）+ Angular SPA 初期化 → 60s
+        page2.wait_for_url("**/dp_apl/usr/**", timeout=60000)
         page2.wait_for_selector("input, button", timeout=30000)
         _wait(2.0, 3.0)
         self.dlog(f"page2 URL: {page2.url}")
@@ -141,20 +145,17 @@ class HifumiCollector(BaseCollector):
         _wait(1.5, 2.5)
         self.save_html(page2, "after_report_button")
 
-        # Angular ルーター遷移後、「PDFファイル」ボタンが visible になるまで待機
+        # Angular ルーター遷移後、「特定口座年間取引報告書...PDFファイル」ボタン visible 待機。
+        # 詳細画面には PDF ボタン複数（投資信託等）並ぶため、has_text="PDFファイル" のみだと
+        # .first が hidden な別 PDF ボタンを掴む可能性 → 厳密パターンで一意特定。
+        target_pdf_pattern = re.compile(r"特定口座年間取引報告書.*PDFファイル")
         try:
-            page2.get_by_role("button").filter(has_text="PDFファイル").first.wait_for(
+            page2.get_by_role("button", name=target_pdf_pattern).first.wait_for(
                 state="visible", timeout=15000
             )
         except Exception:
-            # fallback: link として存在する場合
-            try:
-                page2.get_by_role("link").filter(has_text="PDFファイル").first.wait_for(
-                    state="visible", timeout=10000
-                )
-            except Exception:
-                self.dlog("「PDFファイル」ボタンが visible になりませんでした")
-                return False
+            self.dlog("「特定口座年間取引報告書...PDFファイル」ボタンが visible になりませんでした")
+            return False
         _wait()
         return True
 
@@ -174,8 +175,11 @@ class HifumiCollector(BaseCollector):
             return
 
         self.prepare_directory()
+        # hifumi の詳細画面には PDF ボタン複数（投資信託・特定口座等）並ぶ →
+        # 「特定口座年間取引報告書...PDFファイル」を厳密マッチ（has_text のみだと .first が誤選択）
         pdf_path = capture_dpaw_pdf(
-            page2, self.output_dir, f"{year}_hifumi_nentori.pdf", label=self.name
+            page2, self.output_dir, f"{year}_hifumi_nentori.pdf", label=self.name,
+            button_name_pattern=re.compile(r"特定口座年間取引報告書.*PDFファイル"),
         )
         if pdf_path is None:
             self.log_result("error", [], "PDF 捕捉失敗")
@@ -191,7 +195,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = HifumiCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -164,54 +164,43 @@ class HifumiCollector(BaseCollector):
         _wait()
         return True
 
-    def collect(self) -> None:
-        page = self.launch_browser()
+    def _collect_core(self, page) -> None:
+        page1 = self._wait_for_login(page)
+        year = self.config["target_year"]
+
+        page2 = self._navigate_to_eshishobako(page1)
+
+        date_btn = self._find_date_button(page2, year)
+        if date_btn is None:
+            self.log_result("skip", [], f"{year}年度の書類が見つかりません（日付ボタン 0件）")
+            return
+
+        if not self._open_report_detail(page2, date_btn):
+            self.log_result("skip", [], f"{year}年度の特定口座年間取引報告書ボタンが見つかりません")
+            return
+
+        self.prepare_directory()
+        pdf_path = capture_dpaw_pdf(
+            page2, self.output_dir, f"{year}_hifumi_nentori.pdf", label=self.name
+        )
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 捕捉失敗")
+            return
+
         try:
-            page1 = self._wait_for_login(page)
-            year = self.config["target_year"]
-
-            page2 = self._navigate_to_eshishobako(page1)
-
-            date_btn = self._find_date_button(page2, year)
-            if date_btn is None:
-                self.log_result("skip", [], f"{year}年度の書類が見つかりません（日付ボタン 0件）")
-                return
-
-            if not self._open_report_detail(page2, date_btn):
-                self.log_result("skip", [], f"{year}年度の特定口座年間取引報告書ボタンが見つかりません")
-                return
-
-            self.prepare_directory()
-            pdf_path = capture_dpaw_pdf(
-                page2, self.output_dir, f"{year}_hifumi_nentori.pdf", label=self.name
+            data = convert_pdf_to_json(
+                pdf_path=pdf_path,
+                company=self.name,
+                code=self.code,
+                year=year,
+                raw_files=[str(Path(pdf_path).name)],
             )
-            if pdf_path is None:
-                self.log_result("error", [], "PDF 捕捉失敗")
-                return
-
-            try:
-                data = convert_pdf_to_json(
-                    pdf_path=pdf_path,
-                    company=self.name,
-                    code=self.code,
-                    year=year,
-                    raw_files=[str(Path(pdf_path).name)],
-                )
-                self._write_report_json(data)
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ（ANTHROPIC_API_KEY 未設定等）: {e}")
-
-            self.log_result("success", [pdf_path])
-
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
+            self._write_report_json(data)
         except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
+            print(f"[{self.name}] JSON 変換スキップ（ANTHROPIC_API_KEY 未設定等）: {e}")
+
+        self.log_result("success", [pdf_path])
+
 
 
 def main() -> None:
@@ -219,7 +208,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = HifumiCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -42,8 +42,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}/12", f"{target_year + 1}/01"]
 
 class HifumiCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> object:
         """HAR 確認済み:
@@ -191,8 +191,10 @@ class HifumiCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="ひふみ投信 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = HifumiCollector(year=args.year)
+    collector = HifumiCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -27,7 +27,6 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -198,10 +197,7 @@ class HifumiCollector(BaseCollector):
                     year=year,
                     raw_files=[str(Path(pdf_path).name)],
                 )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
+                self._write_report_json(data)
             except Exception as e:
                 print(f"[{self.name}] JSON 変換スキップ（ANTHROPIC_API_KEY 未設定等）: {e}")
 

--- a/skills/tax-collect/sites/hifumi/collect.py
+++ b/skills/tax-collect/sites/hifumi/collect.py
@@ -32,7 +32,6 @@ import re
 import sys
 from pathlib import Path
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -44,7 +43,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hifumi.rheos.jp/"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/hifumi/site.json
+++ b/skills/tax-collect/sites/hifumi/site.json
@@ -1,10 +1,13 @@
 {
   "name": "ひふみ投信",
   "code": "hifumi",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/hifumi/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://hifumi.rheos.jp/",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import re
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
@@ -201,7 +202,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = MatsuiCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -34,6 +34,12 @@ class MatsuiCollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
+        page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+        if page.locator("frame[name='GM']").count() > 0:
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
+            return
         print(f"[{self.name}] ブラウザでログインしてください（最大5分）")
         page.wait_for_selector("frame[name='GM']", timeout=300_000)
         _wait()

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from urllib.parse import urlparse, parse_qs
@@ -26,7 +25,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.matsui.co.jp/"
@@ -140,8 +138,7 @@ class MatsuiCollector(BaseCollector):
             return None
 
         cd = resp.headers.get("content-disposition", "")
-        m = _RE_FILENAME.search(cd)
-        filename = m.group(1).strip().strip('"\'') if m else fallback_name
+        filename = extract_filename(cd, fallback_name)
         pdf_path = self.output_dir / filename
         pdf_path.write_bytes(body)
         print(f"[{self.name}] PDF 保存: {pdf_path}")
@@ -193,25 +190,6 @@ class MatsuiCollector(BaseCollector):
 
         return downloaded
 
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -223,7 +201,7 @@ class MatsuiCollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -190,29 +190,18 @@ class MatsuiCollector(BaseCollector):
 
         return downloaded
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            popup = self._navigate_to_report_popup(page)
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        popup = self._navigate_to_report_popup(page)
 
-            downloaded = self._download_files(popup)
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        downloaded = self._download_files(popup)
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -220,7 +209,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = MatsuiCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -36,7 +36,7 @@ class MatsuiCollector(BaseCollector):
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
         print(f"[{self.name}] ブラウザでログインしてください")
-        input("トップ画面（フレーム表示）で操作可能になったら Enter を押してください: ")
+        self.prompt("トップ画面（フレーム表示）で操作可能になったら Enter を押してください: ")
         _wait()
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))
         print(f"[{self.name}] セッション状態を保存しました")

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -21,7 +21,6 @@ import sys
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -33,7 +32,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.matsui.co.jp/"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -30,8 +30,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}年12月", f"{target_year + 1}年01月"]
 
 class MatsuiCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -192,8 +192,10 @@ class MatsuiCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="松井証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = MatsuiCollector(year=args.year)
+    collector = MatsuiCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -8,8 +8,7 @@
 
 注意:
     ログインは人間が手動で行う。
-    スクリプト起動後、ブラウザでトップ画面まで到達してから Enter を押すこと。
-    サイトはフレーム構成（frameset）のため、ログイン後もフレームが表示されている状態で Enter を押すこと。
+    スクリプト起動後、ブラウザでログインしてください。フレーム構成（frameset）の表示を自動検出します。
 """
 
 from __future__ import annotations
@@ -35,8 +34,8 @@ class MatsuiCollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
-        print(f"[{self.name}] ブラウザでログインしてください")
-        self.prompt("トップ画面（フレーム表示）で操作可能になったら Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログインしてください（最大5分）")
+        page.wait_for_selector("frame[name='GM']", timeout=300_000)
         _wait()
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))
         print(f"[{self.name}] セッション状態を保存しました")

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -40,11 +40,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class MatsuiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/matsui/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://www.matsui.co.jp/"
 
 from money_ops.utils import extract_filename, wait as _wait
 
@@ -35,7 +34,7 @@ class MatsuiCollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         print(f"[{self.name}] ブラウザでログインしてください")
         input("トップ画面（フレーム表示）で操作可能になったら Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 
@@ -35,8 +33,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.matsui.co.jp/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/matsui/collect.py
+++ b/skills/tax-collect/sites/matsui/collect.py
@@ -16,27 +16,19 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.matsui.co.jp/"
 
-
 from money_ops.utils import extract_filename, wait as _wait
-
 
 def _year_month_patterns(target_year: int) -> list[str]:
     """発行年月の候補: 対象年12月 or 翌年1月（日本語表記）"""
     return [f"{target_year}年12月", f"{target_year + 1}年01月"]
-
 
 class MatsuiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -198,15 +190,12 @@ class MatsuiCollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="松井証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = MatsuiCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/matsui/site.json
+++ b/skills/tax-collect/sites/matsui/site.json
@@ -1,10 +1,13 @@
 {
   "name": "松井証券",
   "code": "matsui",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/matsui/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.matsui.co.jp/",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/matsui/site.json
+++ b/skills/tax-collect/sites/matsui/site.json
@@ -8,6 +8,6 @@
       "type": "特定口座年間取引報告書"
     }
   ],
-  "login_url": "https://www.matsui.co.jp/",
+  "login_url": "https://www.deal.matsui.co.jp/ITS/login/MemberLogin.jsp",
   "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -186,34 +186,23 @@ class MonexCollector(BaseCollector):
 
         return downloaded
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            self._navigate_to_report_list(page)
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        self._navigate_to_report_list(page)
 
-            year = self.config["target_year"]
-            if self._find_xml_link(page, year) is None:
-                self.log_result("skip", [], f"{year}年度の取引報告書が存在しません")
-                return
+        year = self.config["target_year"]
+        if self._find_xml_link(page, year) is None:
+            self.log_result("skip", [], f"{year}年度の取引報告書が存在しません")
+            return
 
-            downloaded = self._download_files(page)
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        downloaded = self._download_files(page)
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -221,7 +210,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = MonexCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -40,7 +40,7 @@ class MonexCollector(BaseCollector):
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             return
         print(f"[{self.name}] ブラウザでログインしてください（OTP含む）")
-        input("トップ画面で操作可能になったら Enter を押してください: ")
+        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()
         page.wait_for_load_state("domcontentloaded")
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -39,11 +39,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class MonexCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/monex/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -25,7 +24,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp"
@@ -154,8 +152,7 @@ class MonexCollector(BaseCollector):
             return None
 
         cd = resp.headers.get("content-disposition", "")
-        m = _RE_FILENAME.search(cd)
-        filename = m.group(1).strip().strip('"\'') if m else fallback_name
+        filename = extract_filename(cd, fallback_name)
         pdf_path = self.output_dir / filename
         pdf_path.write_bytes(body)
         print(f"[{self.name}] PDF 保存: {pdf_path}")
@@ -189,25 +186,6 @@ class MonexCollector(BaseCollector):
 
         return downloaded
 
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -224,7 +202,7 @@ class MonexCollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -9,7 +9,7 @@
 
 注意:
     ログイン・OTP は人間が手動で行う。
-    スクリプト起動後、ブラウザでトップ画面まで到達してから Enter を押すこと。
+    スクリプト起動後、ブラウザでログインしてください。トップ画面到達を自動検出します。
 """
 
 from __future__ import annotations
@@ -39,8 +39,11 @@ class MonexCollector(BaseCollector):
         if isinstance(url, str) and "mst.monex.co.jp" in url and "LoginIDPassword" not in url:
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             return
-        print(f"[{self.name}] ブラウザでログインしてください（OTP含む）")
-        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログインしてください（OTP含む）（最大5分）")
+        page.wait_for_url(
+            lambda url: "mst.monex.co.jp" in url and "LoginIDPassword" not in url,
+            timeout=300_000,
+        )
         _wait()
         page.wait_for_load_state("domcontentloaded")
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
@@ -34,8 +32,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp"
 
 from money_ops.utils import extract_filename, wait as _wait
 
@@ -34,7 +33,7 @@ class MonexCollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         url = page.url
         if isinstance(url, str) and "mst.monex.co.jp" in url and "LoginIDPassword" not in url:

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -29,8 +29,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}年12月", f"{target_year + 1}年01月"]
 
 class MonexCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -193,8 +193,10 @@ class MonexCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="マネックス証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = MonexCollector(year=args.year)
+    collector = MonexCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -160,15 +160,6 @@ class MonexCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-        if not captured["body"]:
-            print(f"[{self.name}] PDF 捕捉できませんでした")
-            return None
-
-        pdf_path = self.output_dir / captured["filename"]
-        pdf_path.write_bytes(captured["body"])
-        print(f"[{self.name}] PDF 保存: {pdf_path}")
-        return str(pdf_path)
-
     def _download_files(self, page) -> list[str]:
         self.prepare_directory()
         year = self.config["target_year"]

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -20,7 +20,6 @@ import re
 import sys
 from pathlib import Path
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -32,7 +31,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -33,17 +33,26 @@ class MonexCollector(BaseCollector):
         super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
+        # 認証中URLのみ除外（LoginScreenTransfer / MailOneTimePwdAuthConfCheck）。
+        # CheckMajorCustmer はログイン完了後ダッシュボード表示時にも残るためダッシュボード扱い。
+        def _is_dashboard(url: str) -> bool:
+            if "mxp3.monex.co.jp" not in url:
+                return False
+            for auth_path in ("/login/LoginScreenTransfer", "MailOneTimePwdAuthConfCheck"):
+                if auth_path in url:
+                    return False
+            return True
+
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
-        url = page.url
-        if isinstance(url, str) and "mst.monex.co.jp" in url and "LoginIDPassword" not in url:
+        _wait(1.5, 2.5)
+        if _is_dashboard(page.url):
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
             return
-        print(f"[{self.name}] ブラウザでログインしてください（OTP含む）（最大5分）")
-        page.wait_for_url(
-            lambda url: "mst.monex.co.jp" in url and "LoginIDPassword" not in url,
-            timeout=300_000,
-        )
+
+        print(f"[{self.name}] ブラウザでログインしてください（OTP含む）（最大10分）")
+        page.wait_for_url(_is_dashboard, timeout=600_000)
         _wait()
         page.wait_for_load_state("domcontentloaded")
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -53,6 +53,11 @@ class MonexCollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)
+        page.wait_for_load_state("domcontentloaded")
+        url = page.url
+        if isinstance(url, str) and "mst.monex.co.jp" in url and "LoginIDPassword" not in url:
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            return
         print(f"[{self.name}] ブラウザでログインしてください（OTP含む）")
         input("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import re
 from pathlib import Path
 
@@ -209,7 +210,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = MonexCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/monex/collect.py
+++ b/skills/tax-collect/sites/monex/collect.py
@@ -16,26 +16,18 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp"
 
-
 from money_ops.utils import extract_filename, wait as _wait
-
 
 def _year_month_patterns(target_year: int) -> list[str]:
     """発行年月の候補: 対象年12月 or 翌年1月（日本語表記）"""
     return [f"{target_year}年12月", f"{target_year + 1}年01月"]
-
 
 class MonexCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -199,15 +191,12 @@ class MonexCollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="マネックス証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = MonexCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/monex/site.json
+++ b/skills/tax-collect/sites/monex/site.json
@@ -1,10 +1,13 @@
 {
   "name": "マネックス証券",
   "code": "monex",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/monex/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://mst.monex.co.jp/pc/ITS/login/LoginIDPassword.jsp",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -118,7 +118,7 @@ class MufgEsmartCollector(BaseCollector):
             _wait(1.0, 2.0)
             if "mfa-email-challenge" in page1.url:
                 print(f"[{self.name}] ワンタイム認証コード（メール）を入力してください")
-                code = input("認証コード: ").strip()
+                code = self.prompt("認証コード: ").strip()
                 page1.get_by_role("textbox", name="ワンタイム認証コード").fill(code)
                 page1.get_by_role("button", name="続ける").click()
                 page1.wait_for_url(
@@ -128,7 +128,7 @@ class MufgEsmartCollector(BaseCollector):
                 _wait(2.0, 3.0)
         else:
             print(f"[{self.name}] page1 でログインしてください（口座番号・パスワード・OTP まですべて完了後 Enter）")
-            input("完了後 Enter: ")
+            self.prompt("完了後 Enter: ")
             page1.wait_for_url(
                 lambda u: "si1.kabu.co.jp" in u or "members" in u,
                 timeout=60000,
@@ -138,7 +138,7 @@ class MufgEsmartCollector(BaseCollector):
         # 契約書類再同意画面が挟まる場合は手動操作を促す
         if "KeiyakuSyoruiSaidoui" in page1.url or "Confirm" in page1.url:
             print(f"[{self.name}] 契約書類再同意画面が表示されました。ブラウザで同意操作を完了してください")
-            input("完了後 Enter: ")
+            self.prompt("完了後 Enter: ")
             _wait(2.0, 3.0)
 
         self._save_session(page)

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -271,44 +271,33 @@ class MufgEsmartCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
+    def _collect_core(self, page) -> None:
+        year = self.config.get("target_year")
+        if year is None:
+            raise ValueError("target_year が設定されていません")
+
+        page1 = self._open_trade_page(page)
+        self._navigate_to_pdf_report(page1)
+
+        pdf_path = self._download_pdf(page1, year)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 取得失敗")
+            return
+
         try:
-            year = self.config.get("target_year")
-            if year is None:
-                raise ValueError("target_year が設定されていません")
-
-            page1 = self._open_trade_page(page)
-            self._navigate_to_pdf_report(page1)
-
-            pdf_path = self._download_pdf(page1, year)
-            if pdf_path is None:
-                self.log_result("error", [], "PDF 取得失敗")
-                return
-
-            try:
-                data = convert_pdf_to_json(
-                    pdf_path=pdf_path,
-                    company=self.name,
-                    code=self.code,
-                    year=year,
-                    raw_files=[str(Path(pdf_path).name)],
-                )
-                self._write_report_json(data)
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ: {e}")
-
-            self.log_result("success", [pdf_path])
-
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
+            data = convert_pdf_to_json(
+                pdf_path=pdf_path,
+                company=self.name,
+                code=self.code,
+                year=year,
+                raw_files=[str(Path(pdf_path).name)],
+            )
+            self._write_report_json(data)
         except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
+            print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+        self.log_result("success", [pdf_path])
+
 
 
 def main() -> None:
@@ -316,7 +305,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = MufgEsmartCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -43,7 +43,6 @@ from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_TOP_URL = "https://kabu.com/"
 
 from money_ops.utils import wait as _wait
 
@@ -71,7 +70,7 @@ class MufgEsmartCollector(BaseCollector):
           - 認証後: mauth-sso callback → s20.si1.kabu.co.jp/members/
           - セッション有効時: Auth0 がフォームをスキップして直接 si1.kabu.co.jp へ
         """
-        page.goto(_TOP_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -35,6 +35,7 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
+import sys
 import json
 import os
 import re
@@ -282,7 +283,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = MufgEsmartCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -47,8 +47,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 from money_ops.utils import wait as _wait
 
 class MufgEsmartCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _save_session(self, page) -> None:
         """cookie が存在する場合のみ storage_state.json を保存（空書き込みで既存 cookie 喪失を防ぐ）。"""
@@ -290,8 +290,10 @@ class MufgEsmartCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="MUFG eスマート証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = MufgEsmartCollector(year=args.year)
+    collector = MufgEsmartCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -41,7 +41,6 @@ import re
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 
@@ -273,18 +272,7 @@ class MufgEsmartCollector(BaseCollector):
             self.log_result("error", [], "PDF 取得失敗")
             return
 
-        try:
-            data = convert_pdf_to_json(
-                pdf_path=pdf_path,
-                company=self.name,
-                code=self.code,
-                year=year,
-                raw_files=[str(Path(pdf_path).name)],
-            )
-            self._write_report_json(data)
-        except Exception as e:
-            print(f"[{self.name}] JSON 変換スキップ: {e}")
-
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
         self.log_result("success", [pdf_path])
 
 def main() -> None:

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -55,11 +55,7 @@ from money_ops.utils import wait as _wait
 
 class MufgEsmartCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/mufg-esmart/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _save_session(self, page) -> None:
         """cookie が存在する場合のみ storage_state.json を保存（空書き込みで既存 cookie 喪失を防ぐ）。"""

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -10,7 +10,8 @@
     MUFGESMART_PASS     パスワード（未設定時は手動入力）
 
 注意:
-    ログイン後のワンタイム認証コード（メール）は必ず手動入力が必要。
+    ログイン後のワンタイム認証コード（メール）はブラウザで直接入力・送信してください。
+    スクリプトはブラウザの状態変化を自動検出します。
 
 実測済みページ構造（HAR確認済み）:
     page:  kabu.com（トップ）
@@ -117,28 +118,27 @@ class MufgEsmartCollector(BaseCollector):
             )
             _wait(1.0, 2.0)
             if "mfa-email-challenge" in page1.url:
-                print(f"[{self.name}] ワンタイム認証コード（メール）を入力してください")
-                code = self.prompt("認証コード: ").strip()
-                page1.get_by_role("textbox", name="ワンタイム認証コード").fill(code)
-                page1.get_by_role("button", name="続ける").click()
+                print(f"[{self.name}] ワンタイム認証コード（メール）をブラウザに入力して送信してください（最大5分）")
                 page1.wait_for_url(
                     lambda u: "si1.kabu.co.jp" in u or "members" in u,
-                    timeout=60000,
+                    timeout=300_000,
                 )
                 _wait(2.0, 3.0)
         else:
-            print(f"[{self.name}] page1 でログインしてください（口座番号・パスワード・OTP まですべて完了後 Enter）")
-            self.prompt("完了後 Enter: ")
+            print(f"[{self.name}] page1 でログインしてください（口座番号・パスワード・OTP まですべて完了）（最大5分）")
             page1.wait_for_url(
                 lambda u: "si1.kabu.co.jp" in u or "members" in u,
-                timeout=60000,
+                timeout=300_000,
             )
             _wait(2.0, 3.0)
 
         # 契約書類再同意画面が挟まる場合は手動操作を促す
         if "KeiyakuSyoruiSaidoui" in page1.url or "Confirm" in page1.url:
-            print(f"[{self.name}] 契約書類再同意画面が表示されました。ブラウザで同意操作を完了してください")
-            self.prompt("完了後 Enter: ")
+            print(f"[{self.name}] 契約書類再同意画面が表示されました。ブラウザで同意操作を完了してください（最大5分）")
+            page1.wait_for_url(
+                lambda u: "KeiyakuSyoruiSaidoui" not in u and "Confirm" not in u,
+                timeout=300_000,
+            )
             _wait(2.0, 3.0)
 
         self._save_session(page)

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -37,11 +37,7 @@ import argparse
 import json
 import os
 import re
-import sys
 from pathlib import Path
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
@@ -49,9 +45,7 @@ from money_ops.converter.pdf_to_json import convert_pdf_to_json
 _SITE_JSON = Path(__file__).parent / "site.json"
 _TOP_URL = "https://kabu.com/"
 
-
 from money_ops.utils import wait as _wait
-
 
 class MufgEsmartCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -294,15 +288,12 @@ class MufgEsmartCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="MUFG eスマート証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = MufgEsmartCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -36,10 +36,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -52,8 +50,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _TOP_URL = "https://kabu.com/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class MufgEsmartCollector(BaseCollector):

--- a/skills/tax-collect/sites/mufg-esmart/collect.py
+++ b/skills/tax-collect/sites/mufg-esmart/collect.py
@@ -294,10 +294,7 @@ class MufgEsmartCollector(BaseCollector):
                     year=year,
                     raw_files=[str(Path(pdf_path).name)],
                 )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
+                self._write_report_json(data)
             except Exception as e:
                 print(f"[{self.name}] JSON 変換スキップ: {e}")
 

--- a/skills/tax-collect/sites/mufg-esmart/site.json
+++ b/skills/tax-collect/sites/mufg-esmart/site.json
@@ -1,10 +1,13 @@
 {
   "name": "MUFG eスマート証券",
   "code": "mufg-esmart",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/mufg-esmart/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://kabu.com/",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -45,8 +45,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}年12月", f"{target_year + 1}年01月"]
 
 class NomuraMochikabuCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -178,8 +178,10 @@ class NomuraMochikabuCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="野村證券持株会 配当金等支払通知書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = NomuraMochikabuCollector(year=args.year)
+    collector = NomuraMochikabuCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -29,7 +29,6 @@ PDF取得方式（T-13方式: context.request 直接フェッチ）:
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from html.parser import HTMLParser
 from pathlib import Path
@@ -44,10 +43,9 @@ _LOGIN_URL = "https://www.e-plan.nomura.co.jp/login/index.html"
 _WEB_KOFU_URL = "https://www.e-plan.nomura.co.jp/mocikabu/script/WEAW1200.jsp"
 _PDF_POST_URL = "https://www.e-plan.nomura.co.jp/cms/ChouhyouDisplayPost.do"
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -52,7 +52,7 @@ class NomuraMochikabuCollector(BaseCollector):
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         print(f"[{self.name}] ブラウザでログインしてください（2FA・ポップアップ処理含む）")
-        input("トップ画面で操作可能になったら Enter を押してください: ")
+        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()
         self.dlog(f"login done, URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -55,11 +55,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class NomuraMochikabuCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/nomura-mochikabu/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -29,6 +29,7 @@ PDF取得方式（T-13方式: context.request 直接フェッチ）:
 from __future__ import annotations
 
 import argparse
+import sys
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -192,7 +193,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = NomuraMochikabuCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -9,7 +9,7 @@
 
 注意:
     ログイン・2FA・ポップアップ処理は人間が手動で行う。
-    スクリプト起動後、ブラウザでログインしてトップ画面到達後 Enter を押すこと。
+    スクリプト起動後、ブラウザでログインしてください。トップ画面到達を自動検出します。
 
 収集対象:
     配当金等支払通知書（Web交付）
@@ -51,8 +51,11 @@ class NomuraMochikabuCollector(BaseCollector):
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
-        print(f"[{self.name}] ブラウザでログインしてください（2FA・ポップアップ処理含む）")
-        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログインしてください（2FA・ポップアップ処理含む）（最大5分）")
+        page.wait_for_url(
+            lambda url: "login" not in url.lower() and "e-plan.nomura.co.jp" in url,
+            timeout=300_000,
+        )
         _wait()
         self.dlog(f"login done, URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -164,8 +164,7 @@ class NomuraMochikabuCollector(BaseCollector):
             return None
 
         cd = pdf_resp.headers.get("content-disposition", "")
-        m = _RE_FILENAME.search(cd)
-        filename = m.group(1).strip().strip('"\'') if m else f"{year}_nomura_mochikabu_haito.pdf"
+        filename = extract_filename(cd, f"{year}_nomura_mochikabu_haito.pdf")
         pdf_path = self.output_dir / filename
         pdf_path.write_bytes(body)
         print(f"[{self.name}] PDF 保存: {pdf_path}")

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -49,13 +49,19 @@ class NomuraMochikabuCollector(BaseCollector):
         super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
+        def _is_dashboard(url: str) -> bool:
+            return "e-plan.nomura.co.jp" in url and "login" not in url.lower()
+
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+        if _is_dashboard(page.url):
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
+            return
+
         print(f"[{self.name}] ブラウザでログインしてください（2FA・ポップアップ処理含む）（最大5分）")
-        page.wait_for_url(
-            lambda url: "login" not in url.lower() and "e-plan.nomura.co.jp" in url,
-            timeout=300_000,
-        )
+        page.wait_for_url(_is_dashboard, timeout=300_000)
         _wait()
         self.dlog(f"login done, URL: {page.url}")
         self.save_html(page, "after_login")
@@ -69,6 +75,7 @@ class NomuraMochikabuCollector(BaseCollector):
         self.save_html(page, "weaw1200_before_filter")
 
         # chohyoType=3（配当金等支払通知書）を選択 → onchange で自動フォームサブミット
+        page.locator("#chohyoType").wait_for(state="visible", timeout=60_000)
         page.locator("#chohyoType").select_option("3")
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -35,7 +35,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://www.e-plan.nomura.co.jp/login/index.html"
 _WEB_KOFU_URL = "https://www.e-plan.nomura.co.jp/mocikabu/script/WEAW1200.jsp"
 _PDF_POST_URL = "https://www.e-plan.nomura.co.jp/cms/ChouhyouDisplayPost.do"
 
@@ -50,7 +49,7 @@ class NomuraMochikabuCollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         print(f"[{self.name}] ブラウザでログインしてください（2FA・ポップアップ処理含む）")
         input("トップ画面で操作可能になったら Enter を押してください: ")

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -29,10 +29,8 @@ PDF取得方式（T-13方式: context.request 直接フェッチ）:
 from __future__ import annotations
 
 import argparse
-import random
 import re
 import sys
-import time
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -49,8 +47,7 @@ _PDF_POST_URL = "https://www.e-plan.nomura.co.jp/cms/ChouhyouDisplayPost.do"
 _RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -170,35 +170,24 @@ class NomuraMochikabuCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            year = self.config["target_year"]
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        year = self.config["target_year"]
 
-            self._navigate_to_list(page)
+        self._navigate_to_list(page)
 
-            report_link = self._find_report_link(page, year)
-            if report_link is None:
-                self.log_result("skip", [], f"{year}年度の配当金等支払通知書が見つかりません")
-                return
+        report_link = self._find_report_link(page, year)
+        if report_link is None:
+            self.log_result("skip", [], f"{year}年度の配当金等支払通知書が見つかりません")
+            return
 
-            pdf_path = self._download_pdf(page, report_link)
-            if pdf_path is None:
-                self.log_result("error", [], "PDF ダウンロードに失敗しました")
-                return
+        pdf_path = self._download_pdf(page, report_link)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF ダウンロードに失敗しました")
+            return
 
-            self.log_result("success", [pdf_path])
+        self.log_result("success", [pdf_path])
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -206,7 +195,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = NomuraMochikabuCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/nomura-mochikabu/collect.py
+++ b/skills/tax-collect/sites/nomura-mochikabu/collect.py
@@ -29,12 +29,8 @@ PDF取得方式（T-13方式: context.request 直接フェッチ）:
 from __future__ import annotations
 
 import argparse
-import sys
 from html.parser import HTMLParser
 from pathlib import Path
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
@@ -43,15 +39,11 @@ _LOGIN_URL = "https://www.e-plan.nomura.co.jp/login/index.html"
 _WEB_KOFU_URL = "https://www.e-plan.nomura.co.jp/mocikabu/script/WEAW1200.jsp"
 _PDF_POST_URL = "https://www.e-plan.nomura.co.jp/cms/ChouhyouDisplayPost.do"
 
-
-
 from money_ops.utils import extract_filename, wait as _wait
-
 
 def _year_month_patterns(target_year: int) -> list[str]:
     """発行年月の候補: 対象年12月 or 翌年1月"""
     return [f"{target_year}年12月", f"{target_year + 1}年01月"]
-
 
 class NomuraMochikabuCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -184,15 +176,12 @@ class NomuraMochikabuCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="野村證券持株会 配当金等支払通知書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = NomuraMochikabuCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/nomura-mochikabu/site.json
+++ b/skills/tax-collect/sites/nomura-mochikabu/site.json
@@ -1,10 +1,13 @@
 {
   "name": "野村證券持株会",
   "code": "nomura-mochikabu",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/nomura-mochikabu/2025/raw/",
   "documents": [
-    { "type": "配当金等支払通知書" }
-  ]
+    {
+      "type": "配当金等支払通知書"
+    }
+  ],
+  "login_url": "https://www.e-plan.nomura.co.jp/login/index.html",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -9,8 +9,7 @@
 
 注意:
     ログイン・2FA は人間が手動で行う。
-    スクリプト起動後、ブラウザでログインしてトップ画面到達後 Enter を押すこと。
-    取引報告書Web交付の取引パスワード入力も人間が行う。
+    スクリプト起動後、ブラウザでログインしてください。トップ画面到達・取引パスワード入力完了を自動検出します。
 """
 
 from __future__ import annotations
@@ -42,8 +41,11 @@ class NomuraCollector(BaseCollector):
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             self._session = page
             return
-        print(f"[{self.name}] ブラウザでログインしてください（メール認証コード含む）")
-        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログインしてください（メール認証コード含む）（最大5分）")
+        page.wait_for_url(
+            lambda url: "hometrade.nomura.co.jp" in url and "login" not in url.lower(),
+            timeout=300_000,
+        )
         _wait()
         # goto で hometrade.nomura.co.jp へ直接遷移しているため page 自体がセッション
         self._session = page
@@ -66,8 +68,7 @@ class NomuraCollector(BaseCollector):
         self.dlog(f"report popup URL: {popup.url}")
         self.save_html(popup, "report_popup_before_tradepw")
 
-        print(f"[{self.name}] 取引パスワードを入力・認証後、書類一覧が表示されたら Enter を押してください")
-        self.prompt("Enter を押してください: ")
+        print(f"[{self.name}] 取引パスワードをブラウザで入力・認証してください（最大5分）")
 
         # e-shishobako Angular SPA 初期化完了を待機
         # wait_for_url で dp_apl/usr/ へのルーティング完了を確認後、レンダリング待ち

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import re
 from pathlib import Path
 
@@ -167,7 +168,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = NomuraCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -43,7 +43,7 @@ class NomuraCollector(BaseCollector):
             self._session = page
             return
         print(f"[{self.name}] ブラウザでログインしてください（メール認証コード含む）")
-        input("トップ画面で操作可能になったら Enter を押してください: ")
+        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()
         # goto で hometrade.nomura.co.jp へ直接遷移しているため page 自体がセッション
         self._session = page
@@ -67,7 +67,7 @@ class NomuraCollector(BaseCollector):
         self.save_html(popup, "report_popup_before_tradepw")
 
         print(f"[{self.name}] 取引パスワードを入力・認証後、書類一覧が表示されたら Enter を押してください")
-        input("Enter を押してください: ")
+        self.prompt("Enter を押してください: ")
 
         # e-shishobako Angular SPA 初期化完了を待機
         # wait_for_url で dp_apl/usr/ へのルーティング完了を確認後、レンダリング待ち

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -41,11 +41,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class NomuraCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/nomura/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -21,7 +21,6 @@ import re
 import sys
 from pathlib import Path
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -33,7 +32,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do"
 
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
@@ -36,7 +35,7 @@ class NomuraCollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         url = page.url
         if isinstance(url, str) and "hometrade.nomura.co.jp" in url and "login" not in url.lower():

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -34,18 +34,24 @@ class NomuraCollector(BaseCollector):
         super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
+        def _is_dashboard(url: str) -> bool:
+            return (
+                "hometrade.nomura.co.jp" in url
+                and "login" not in url.lower()
+                and "rmfIndexWebAction" not in url
+            )
+
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
         url = page.url
-        if isinstance(url, str) and "hometrade.nomura.co.jp" in url and "login" not in url.lower():
+        if isinstance(url, str) and _is_dashboard(url):
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             self._session = page
             return
-        print(f"[{self.name}] ブラウザでログインしてください（メール認証コード含む）（最大5分）")
-        page.wait_for_url(
-            lambda url: "hometrade.nomura.co.jp" in url and "login" not in url.lower(),
-            timeout=300_000,
-        )
+
+        print(f"[{self.name}] ブラウザでログインしてください（メール認証コード含む）（最大10分）")
+        page.wait_for_url(_is_dashboard, timeout=600_000)
         _wait()
         # goto で hometrade.nomura.co.jp へ直接遷移しているため page 自体がセッション
         self._session = page

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -17,27 +17,19 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do"
 
-
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
-
 
 def _year_month_patterns(target_year: int) -> list[str]:
     """発行年月の候補: 対象年12月 or 翌年1月（GMO-clickと同形式）"""
     return [f"{target_year}/12", f"{target_year + 1}/01"]
-
 
 class NomuraCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -162,15 +154,12 @@ class NomuraCollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="野村證券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = NomuraCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -54,6 +54,12 @@ class NomuraCollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)
+        page.wait_for_load_state("domcontentloaded")
+        url = page.url
+        if isinstance(url, str) and "hometrade.nomura.co.jp" in url and "login" not in url.lower():
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self._session = page
+            return
         print(f"[{self.name}] ブラウザでログインしてください（メール認証コード含む）")
         input("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -32,7 +32,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do"
 
 
-from money_ops.utils import extract_filename, wait as _wait
+from money_ops.collector.eshishobako import capture_dpaw_pdf
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:
@@ -103,47 +104,6 @@ class NomuraCollector(BaseCollector):
                 return btn.first
         return None
 
-    def _download_pdf_via_route(self, popup, fallback_name: str) -> str | None:
-        """context.route() で DPAW010501020 の PDF レスポンスを捕捉して保存
-        PDF ボタンクリック → blob URL ポップアップが開く → 閉じてから unroute（GMO-clickと同方式）"""
-        pdf_btn = popup.locator("button, a").filter(has_text="PDFファイル")
-        if pdf_btn.count() == 0:
-            print(f"[{self.name}] PDF ボタンが見つかりません")
-            return None
-
-        pdf_bytes_holder: list[tuple[str, bytes]] = []
-
-        def _capture_pdf(route, _request) -> None:
-            response = route.fetch()
-            body = response.body()
-            if body[:4] == b"%PDF":
-                cd = response.headers.get("content-disposition", "")
-                m = _RE_FILENAME.search(cd)
-                filename = m.group(1).strip().strip('"\'') if m else fallback_name
-                pdf_bytes_holder.append((filename, body))
-            route.fulfill(response=response)
-
-        popup.context.route("**/DPAW010501020", _capture_pdf)
-        try:
-            with popup.expect_popup() as pdf_popup_info:
-                pdf_btn.first.click()
-            pdf_popup = pdf_popup_info.value
-            pdf_popup.wait_for_load_state("domcontentloaded")
-            _wait()
-            pdf_popup.close()
-        finally:
-            popup.context.unroute("**/DPAW010501020", _capture_pdf)
-
-        if not pdf_bytes_holder:
-            print(f"[{self.name}] PDF レスポンスを捕捉できませんでした")
-            return None
-
-        filename, pdf_bytes = pdf_bytes_holder[0]
-        pdf_path = self.output_dir / filename
-        pdf_path.write_bytes(pdf_bytes)
-        print(f"[{self.name}] PDF 保存: {pdf_path}")
-        return str(pdf_path)
-
     def _download_files(self, popup) -> list[str]:
         self.prepare_directory()
         year = self.config["target_year"]
@@ -180,8 +140,10 @@ class NomuraCollector(BaseCollector):
         else:
             print(f"[{self.name}] XML ボタンが見つかりません")
 
-        # PDF（e-shishobako DPAW010501020 ルート捕捉。GMO-clickと完全同方式）
-        pdf_path = self._download_pdf_via_route(popup, f"{year}_nentori.pdf")
+        # PDF（e-shishobako DPAW010501020 ルート捕捉）
+        pdf_path = capture_dpaw_pdf(
+            popup, self.output_dir, f"{year}_nentori.pdf", label=self.name
+        )
         if pdf_path:
             downloaded.append(pdf_path)
             _wait()

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -31,8 +31,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}/12", f"{target_year + 1}/01"]
 
 class NomuraCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -156,8 +156,10 @@ class NomuraCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="野村證券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = NomuraCollector(year=args.year)
+    collector = NomuraCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -148,35 +148,24 @@ class NomuraCollector(BaseCollector):
 
         return downloaded
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            self._save_session_state(page)
-            popup = self._navigate_to_report_popup()
-            year = self.config["target_year"]
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        self._save_session_state(page)
+        popup = self._navigate_to_report_popup()
+        year = self.config["target_year"]
 
-            if self._find_report_row_button(popup, year) is None:
-                self.log_result("skip", [], f"{year}年度の取引報告書が存在しません")
-                return
+        if self._find_report_row_button(popup, year) is None:
+            self.log_result("skip", [], f"{year}年度の取引報告書が存在しません")
+            return
 
-            downloaded = self._download_files(popup)
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        downloaded = self._download_files(popup)
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -184,7 +173,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = NomuraCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -17,10 +17,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
@@ -35,8 +33,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -26,7 +25,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do"
@@ -150,25 +148,6 @@ class NomuraCollector(BaseCollector):
 
         return downloaded
 
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -186,7 +165,7 @@ class NomuraCollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/nomura/collect.py
+++ b/skills/tax-collect/sites/nomura/collect.py
@@ -209,6 +209,7 @@ class NomuraCollector(BaseCollector):
         page = self.launch_browser()
         try:
             self._wait_for_login(page)
+            self._save_session_state(page)
             popup = self._navigate_to_report_popup()
             year = self.config["target_year"]
 

--- a/skills/tax-collect/sites/nomura/site.json
+++ b/skills/tax-collect/sites/nomura/site.json
@@ -1,10 +1,13 @@
 {
   "name": "野村證券",
   "code": "nomura",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/nomura/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -33,7 +33,6 @@ from pathlib import Path
 from urllib.parse import urljoin
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _TRADE_URL = "https://www.paypay-sec.co.jp/trade/"
@@ -183,18 +182,7 @@ class PaypayCollector(BaseCollector):
             self.log_result("error", [], "PDF 取得失敗")
             return
 
-        try:
-            data = convert_pdf_to_json(
-                pdf_path=pdf_path,
-                company=self.name,
-                code=self.code,
-                year=year,
-                raw_files=[str(Path(pdf_path).name)],
-            )
-            self._write_report_json(data)
-        except Exception as e:
-            print(f"[{self.name}] JSON 変換スキップ: {e}")
-
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
         self.log_result("success", [pdf_path])
 
 def main() -> None:

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -87,7 +87,7 @@ class PaypayCollector(BaseCollector):
             self.save_html(page, "after_credential_submit")
         else:
             print(f"[{self.name}] 会員ID・パスワードをブラウザで入力してログインボタンを押してください")
-            input("ログインボタン押下後 Enter: ")
+            self.prompt("ログインボタン押下後 Enter: ")
 
         # emailauth か /trade/ のどちらかに遷移するまで待つ
         page.wait_for_url(
@@ -100,7 +100,7 @@ class PaypayCollector(BaseCollector):
         # SMS 認証
         if "emailauth" in page.url:
             print(f"[{self.name}] SMS 認証コード（6桁）を入力してください")
-            code = input("コード: ").strip()
+            code = self.prompt("コード: ").strip()
             if len(code) != 6 or not code.isdigit():
                 raise ValueError(f"SMS コードは6桁の数字です: {code!r}")
             for i, digit in enumerate(code, 1):

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -10,7 +10,8 @@
     PAYPAY_PASS     パスワード（未設定時は手動入力）
 
 注意:
-    SMS 認証コード（6桁）は必ず手動入力が必要。
+    SMS 認証コード（6桁）はブラウザで直接入力・送信してください。
+    スクリプトはブラウザの状態変化を自動検出します。
 
 実測済みページ構造（HAR確認済み）:
     page: paypay-sec.co.jp/ → /account/login/ → /login/
@@ -86,8 +87,7 @@ class PaypayCollector(BaseCollector):
             _wait(2.0, 3.0)
             self.save_html(page, "after_credential_submit")
         else:
-            print(f"[{self.name}] 会員ID・パスワードをブラウザで入力してログインボタンを押してください")
-            self.prompt("ログインボタン押下後 Enter: ")
+            print(f"[{self.name}] 会員ID・パスワードをブラウザで入力してログインボタンを押してください（最大5分）")
 
         # emailauth か /trade/ のどちらかに遷移するまで待つ
         page.wait_for_url(
@@ -99,14 +99,8 @@ class PaypayCollector(BaseCollector):
 
         # SMS 認証
         if "emailauth" in page.url:
-            print(f"[{self.name}] SMS 認証コード（6桁）を入力してください")
-            code = self.prompt("コード: ").strip()
-            if len(code) != 6 or not code.isdigit():
-                raise ValueError(f"SMS コードは6桁の数字です: {code!r}")
-            for i, digit in enumerate(code, 1):
-                page.locator(f"#code{i}").fill(digit)
-            page.locator("#btn_sms_success").click()
-            page.wait_for_url("**/trade/**", timeout=120000)
+            print(f"[{self.name}] SMS 認証コード（6桁）をブラウザに入力して送信してください（最大5分）")
+            page.wait_for_url("**/trade/**", timeout=300_000)
             _wait(2.0, 3.0)
 
         self.dlog(f"trade URL: {page.url}")

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -28,6 +28,7 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
+import sys
 import os
 from pathlib import Path
 from urllib.parse import urljoin
@@ -192,7 +193,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = PaypayCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -28,12 +28,8 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 from pathlib import Path
 from urllib.parse import urljoin
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
@@ -42,9 +38,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _TOP_URL = "https://www.paypay-sec.co.jp/"
 _TRADE_URL = "https://www.paypay-sec.co.jp/trade/"
 
-
 from money_ops.utils import wait as _wait
-
 
 class PaypayCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -210,15 +204,12 @@ class PaypayCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="PayPay証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = PaypayCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -27,7 +27,6 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 from pathlib import Path
@@ -211,10 +210,7 @@ class PaypayCollector(BaseCollector):
                     year=year,
                     raw_files=[str(Path(pdf_path).name)],
                 )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
+                self._write_report_json(data)
             except Exception as e:
                 print(f"[{self.name}] JSON 変換スキップ: {e}")
 

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -185,46 +185,35 @@ class PaypayCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
+    def _collect_core(self, page) -> None:
+        year = self.config.get("target_year")
+        if year is None:
+            raise ValueError("target_year が設定されていません")
+
+        if not self._is_logged_in(page):
+            self._login(page)
+
+        self._navigate_to_documents(page)
+
+        pdf_path = self._download_pdf(page, year)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 取得失敗")
+            return
+
         try:
-            year = self.config.get("target_year")
-            if year is None:
-                raise ValueError("target_year が設定されていません")
-
-            if not self._is_logged_in(page):
-                self._login(page)
-
-            self._navigate_to_documents(page)
-
-            pdf_path = self._download_pdf(page, year)
-            if pdf_path is None:
-                self.log_result("error", [], "PDF 取得失敗")
-                return
-
-            try:
-                data = convert_pdf_to_json(
-                    pdf_path=pdf_path,
-                    company=self.name,
-                    code=self.code,
-                    year=year,
-                    raw_files=[str(Path(pdf_path).name)],
-                )
-                self._write_report_json(data)
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ: {e}")
-
-            self.log_result("success", [pdf_path])
-
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
+            data = convert_pdf_to_json(
+                pdf_path=pdf_path,
+                company=self.name,
+                code=self.code,
+                year=year,
+                raw_files=[str(Path(pdf_path).name)],
+            )
+            self._write_report_json(data)
         except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
+            print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+        self.log_result("success", [pdf_path])
+
 
 
 def main() -> None:
@@ -232,7 +221,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = PaypayCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -29,9 +29,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import random
 import sys
-import time
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -46,8 +44,7 @@ _TOP_URL = "https://www.paypay-sec.co.jp/"
 _TRADE_URL = "https://www.paypay-sec.co.jp/trade/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class PaypayCollector(BaseCollector):

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -40,8 +40,8 @@ _TRADE_URL = "https://www.paypay-sec.co.jp/trade/"
 from money_ops.utils import wait as _wait
 
 class PaypayCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _is_logged_in(self, page) -> bool:
         """セッション有効チェック: /trade/ にアクセスして確認。
@@ -206,8 +206,10 @@ class PaypayCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="PayPay証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = PaypayCollector(year=args.year)
+    collector = PaypayCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -63,18 +63,24 @@ class PaypayCollector(BaseCollector):
           - SMS 6桁（#code1-#code6） → #btn_sms_success クリック
             → POST /noauth/emailauth/verify_otp_code (otp_prefix は hidden field 自動送信)
           - 認証後: /trade/ へリダイレクト
+
+        最適化: cookie 残存時は _is_logged_in が /trade/→/login/ にリダイレクトして
+        page.url が既に /login/ になっている。この状態で top 経由再遷移すると
+        /login/→/→/account/login/→/login/ と「行き来」する → 既に /login/ 系なら
+        top 経由スキップして直接 credential 入力へ進む。
         """
-        page.goto(self.config["login_url"])
-        page.wait_for_load_state("domcontentloaded")
-        _wait(1.5, 2.5)
+        if "/login/" not in page.url and "/account/login/" not in page.url:
+            page.goto(self.config["login_url"])
+            page.wait_for_load_state("domcontentloaded")
+            _wait(1.5, 2.5)
 
-        page.get_by_role("link", name="ログイン").first.click()
-        page.wait_for_load_state("domcontentloaded")
-        _wait(1.0, 2.0)
+            page.get_by_role("link", name="ログイン").first.click()
+            page.wait_for_load_state("domcontentloaded")
+            _wait(1.0, 2.0)
 
-        page.get_by_role("link", name="PC取引画面へログイン").first.click()
-        page.wait_for_load_state("domcontentloaded")
-        _wait(1.0, 2.0)
+            page.get_by_role("link", name="PC取引画面へログイン").first.click()
+            page.wait_for_load_state("domcontentloaded")
+            _wait(1.0, 2.0)
         self.dlog(f"login page URL: {page.url}")
 
         user = os.environ.get("PAYPAY_USER", "")
@@ -89,10 +95,10 @@ class PaypayCollector(BaseCollector):
         else:
             print(f"[{self.name}] 会員ID・パスワードをブラウザで入力してログインボタンを押してください（最大5分）")
 
-        # emailauth か /trade/ のどちらかに遷移するまで待つ
+        # emailauth か /trade/ のどちらかに遷移するまで待つ（手動入力時間考慮で 5分）
         page.wait_for_url(
             lambda url: "emailauth" in url or "/trade/" in url,
-            timeout=60000,
+            timeout=300_000,
         )
         _wait(1.0, 2.0)
         self.dlog(f"after login URL: {page.url}")

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -48,11 +48,7 @@ from money_ops.utils import wait as _wait
 
 class PaypayCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/paypay/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _is_logged_in(self, page) -> bool:
         """セッション有効チェック: /trade/ にアクセスして確認。

--- a/skills/tax-collect/sites/paypay/collect.py
+++ b/skills/tax-collect/sites/paypay/collect.py
@@ -35,7 +35,6 @@ from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_TOP_URL = "https://www.paypay-sec.co.jp/"
 _TRADE_URL = "https://www.paypay-sec.co.jp/trade/"
 
 from money_ops.utils import wait as _wait
@@ -64,7 +63,7 @@ class PaypayCollector(BaseCollector):
             → POST /noauth/emailauth/verify_otp_code (otp_prefix は hidden field 自動送信)
           - 認証後: /trade/ へリダイレクト
         """
-        page.goto(_TOP_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 
@@ -158,7 +157,7 @@ class PaypayCollector(BaseCollector):
             print(f"[{self.name}] HREF 属性なし")
             return None
 
-        dl_url = urljoin(_TOP_URL, href)
+        dl_url = urljoin(self.config["login_url"], href)
         self.dlog(f"PDF download URL: {dl_url}")
 
         response = page.request.get(dl_url)

--- a/skills/tax-collect/sites/paypay/site.json
+++ b/skills/tax-collect/sites/paypay/site.json
@@ -1,10 +1,13 @@
 {
   "name": "PayPay証券",
   "code": "paypay",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/paypay/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.paypay-sec.co.jp/",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -15,9 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import sys
-import time
 from datetime import datetime
 from pathlib import Path
 
@@ -31,8 +29,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.rakuten-sec.co.jp/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class RakutenCollector(BaseCollector):

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -51,6 +51,8 @@ class RakutenCollector(BaseCollector):
         print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）")
         input("ログイン完了後、Enter を押してください: ")
         _wait()
+        self.dlog(f"URL: {page.url}")
+        self.save_html(page, "after_login")
 
     # ------------------------------------------------------------------
     # 電子書面一覧ページへ移動
@@ -66,6 +68,8 @@ class RakutenCollector(BaseCollector):
         _wait()
         page.get_by_role("link", name="取引報告書等(電子書面)").first.click()
         _wait()
+        self.dlog(f"URL: {page.url}")
+        self.save_html(page, "report_list")
 
     # ------------------------------------------------------------------
     # 対象年度の行を特定してダウンロード

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -23,7 +22,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.rakuten-sec.co.jp/"
@@ -153,28 +151,6 @@ class RakutenCollector(BaseCollector):
     # ------------------------------------------------------------------
     # JSON 変換
     # ------------------------------------------------------------------
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
-    # ------------------------------------------------------------------
     # メイン収集フロー
     # ------------------------------------------------------------------
     def collect(self) -> None:
@@ -195,7 +171,7 @@ class RakutenCollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://www.rakuten-sec.co.jp/"
 
 from money_ops.utils import extract_filename, wait as _wait
 
@@ -32,7 +31,7 @@ class RakutenCollector(BaseCollector):
     # 手動ログイン待機
     # ------------------------------------------------------------------
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）")
         input("ログイン完了後、Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -33,7 +33,7 @@ class RakutenCollector(BaseCollector):
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
         print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）")
-        input("ログイン完了後、Enter を押してください: ")
+        self.prompt("ログイン完了後、Enter を押してください: ")
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -29,7 +29,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.rakuten-sec.co.jp/"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 class RakutenCollector(BaseCollector):
@@ -115,9 +115,7 @@ class RakutenCollector(BaseCollector):
                     try:
                         # Content-Disposition からオリジナルファイル名を取得
                         cd = response.headers.get("content-disposition", "")
-                        import re as _re
-                        m = _re.search(r'filename[^;=\n]*=([^;\n]*)', cd)
-                        fn = m.group(1).strip().strip('"\'') if m else ""
+                        fn = extract_filename(cd)
                         if not fn:
                             fn = request.url.rstrip("/").split("/")[-1].split("?")[0]
                         if not fn.lower().endswith(".pdf"):

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -193,7 +194,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = RakutenCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -153,36 +153,25 @@ class RakutenCollector(BaseCollector):
     # ------------------------------------------------------------------
     # メイン収集フロー
     # ------------------------------------------------------------------
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            self._save_session_state(page)
-            self._navigate_to_report_list(page)
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        self._save_session_state(page)
+        self._navigate_to_report_list(page)
 
-            year = self.config["target_year"]
-            if page.locator(f"tr:has(td span:text-is('{year}'))").count() == 0:
-                self.log_result("skip", [], f"{year}年の取引報告書が存在しません")
-                return
+        year = self.config["target_year"]
+        if page.locator(f"tr:has(td span:text-is('{year}'))").count() == 0:
+            self.log_result("skip", [], f"{year}年の取引報告書が存在しません")
+            return
 
-            downloaded = self._download_files(page)
+        downloaded = self._download_files(page)
 
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -195,7 +184,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     collector = RakutenCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -31,19 +31,32 @@ class RakutenCollector(BaseCollector):
     # 手動ログイン待機
     # ------------------------------------------------------------------
     def _wait_for_login(self, page) -> None:
+        def _is_dashboard(url: str) -> bool:
+            return (
+                "member.rakuten-sec.co.jp/app/" in url
+                and "Login" not in url
+                and "MhLogin" not in url
+            )
+
         page.goto(self.config["login_url"])
-        # ログイン済み確認（URL で判定）
-        if "rakuten-sec.co.jp" in page.url and "login" not in page.url.lower():
-            btn = page.locator('button[aria-label*="マイメニュー"]')
-            if btn.count() > 0:
-                print(f"[{self.name}] ログイン済みを検出 → スキップ")
-                return
+        page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+        if _is_dashboard(page.url):
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
+            return
+
+        # セッション切れ → ログインフォームへ
+        page.goto(self.config["login_url"])
+        page.wait_for_load_state("domcontentloaded")
         print(f"[{self.name}] ブラウザでログインしてください（絵文字認証・二段階認証含む）（最大10分）")
-        # 2FA中間URLで誤発火しないよう、ダッシュボードのボタン出現を待つ
-        page.wait_for_selector('button[aria-label*="マイメニュー"]', timeout=600_000)
+        page.wait_for_url(
+            lambda url: _is_dashboard(url),
+            timeout=600_000,
+        )
         _wait()
         self.dlog(f"URL: {page.url}")
-        self.save_html(page, "after_login")
+        self.save_html(page, "01_after_login")
 
     # ------------------------------------------------------------------
     # 電子書面一覧ページへ移動

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -14,21 +14,15 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from datetime import datetime
 from pathlib import Path
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.rakuten-sec.co.jp/"
 
-
 from money_ops.utils import extract_filename, wait as _wait
-
 
 class RakutenCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -168,8 +162,6 @@ class RakutenCollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="楽天証券 年間取引報告書収集")
     parser.add_argument(
@@ -181,7 +173,6 @@ def main() -> None:
     args = parser.parse_args()
     collector = RakutenCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -32,11 +32,7 @@ from money_ops.utils import extract_filename, wait as _wait
 
 class RakutenCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/rakuten/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     # ------------------------------------------------------------------
     # 手動ログイン待機

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -8,7 +8,7 @@
 
 注意:
     ログイン・絵文字認証は人間が手動で行う。
-    スクリプト起動後、ブラウザでログインを完了してから Enter を押すこと。
+    スクリプト起動後、ブラウザでログインしてください。ログイン完了を自動検出します。
 """
 
 from __future__ import annotations
@@ -32,8 +32,11 @@ class RakutenCollector(BaseCollector):
     # ------------------------------------------------------------------
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
-        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）")
-        self.prompt("ログイン完了後、Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）（最大5分）")
+        page.wait_for_url(
+            lambda url: "rakuten-sec.co.jp" in url and "login" not in url.lower(),
+            timeout=300_000,
+        )
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -24,8 +24,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 from money_ops.utils import extract_filename, wait as _wait
 
 class RakutenCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     # ------------------------------------------------------------------
     # 手動ログイン待機
@@ -169,8 +169,10 @@ def main() -> None:
         default=None,
         help="対象年度（未指定時は site.json の target_year を使用）",
     )
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = RakutenCollector(year=args.year)
+    collector = RakutenCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -182,6 +182,7 @@ class RakutenCollector(BaseCollector):
         page = self.launch_browser()
         try:
             self._wait_for_login(page)
+            self._save_session_state(page)
             self._navigate_to_report_list(page)
 
             year = self.config["target_year"]

--- a/skills/tax-collect/sites/rakuten/collect.py
+++ b/skills/tax-collect/sites/rakuten/collect.py
@@ -32,11 +32,15 @@ class RakutenCollector(BaseCollector):
     # ------------------------------------------------------------------
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
-        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証含む）（最大5分）")
-        page.wait_for_url(
-            lambda url: "rakuten-sec.co.jp" in url and "login" not in url.lower(),
-            timeout=300_000,
-        )
+        # ログイン済み確認（URL で判定）
+        if "rakuten-sec.co.jp" in page.url and "login" not in page.url.lower():
+            btn = page.locator('button[aria-label*="マイメニュー"]')
+            if btn.count() > 0:
+                print(f"[{self.name}] ログイン済みを検出 → スキップ")
+                return
+        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証・二段階認証含む）（最大10分）")
+        # 2FA中間URLで誤発火しないよう、ダッシュボードのボタン出現を待つ
+        page.wait_for_selector('button[aria-label*="マイメニュー"]', timeout=600_000)
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/rakuten/site.json
+++ b/skills/tax-collect/sites/rakuten/site.json
@@ -8,6 +8,6 @@
       "type": "特定口座年間取引報告書"
     }
   ],
-  "login_url": "https://www.rakuten-sec.co.jp/",
+  "login_url": "https://member.rakuten-sec.co.jp/app/MhLogin.do?login_type=1",
   "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/rakuten/site.json
+++ b/skills/tax-collect/sites/rakuten/site.json
@@ -1,10 +1,13 @@
 {
   "name": "楽天証券",
   "code": "rakuten",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/rakuten/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.rakuten-sec.co.jp/",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -37,9 +37,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import random
 import sys
-import time
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -53,8 +51,7 @@ _LOGIN_URL = "https://fv.sawakami.co.jp/Account/Login"
 _EDELIVERY_URL = "https://fv.sawakami.co.jp/e-delivery"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class SawakamiCollector(BaseCollector):

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -37,11 +37,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 from pathlib import Path
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
@@ -50,9 +46,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://fv.sawakami.co.jp/Account/Login"
 _EDELIVERY_URL = "https://fv.sawakami.co.jp/e-delivery"
 
-
 from money_ops.utils import wait as _wait
-
 
 class SawakamiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -237,15 +231,12 @@ class SawakamiCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="さわかみ投信 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = SawakamiCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -48,8 +48,8 @@ _EDELIVERY_URL = "https://fv.sawakami.co.jp/e-delivery"
 from money_ops.utils import wait as _wait
 
 class SawakamiCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _is_logged_in(self, page) -> bool:
         """セッション有効チェック: /e-delivery にアクセスしてログイン済みか確認。
@@ -233,8 +233,10 @@ class SawakamiCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="さわかみ投信 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = SawakamiCollector(year=args.year)
+    collector = SawakamiCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -10,7 +10,8 @@
     SAWAKAMI_PASS   ログインパスワード（未設定時は手動入力）
 
 注意:
-    メール認証コード（6桁）は必ず手動入力が必要。
+    メール認証コード（6桁）はブラウザで直接入力・送信してください。
+    スクリプトはブラウザの状態変化を自動検出します。
 
 実測済みページ構造（HAR確認済み）:
     GET  /Account/Login
@@ -88,8 +89,7 @@ class SawakamiCollector(BaseCollector):
             _wait(2.0, 3.0)
             self.save_html(page, "after_credential_submit")
         else:
-            print(f"[{self.name}] ログインID・パスワードをブラウザで入力してログインボタンを押してください")
-            self.prompt("ログインボタン押下後 Enter: ")
+            print(f"[{self.name}] ログインID・パスワードをブラウザで入力してログインボタンを押してください（最大5分）")
 
         # twofactorauth か home のどちらかを待つ
         page.wait_for_url(
@@ -104,13 +104,10 @@ class SawakamiCollector(BaseCollector):
 
         # メール 2FA
         if "twofactorauth" in page.url:
-            print(f"[{self.name}] メール認証コードを入力してください")
-            code = self.prompt("認証コード: ").strip()
-            page.get_by_role("spinbutton", name="認証コード").fill(code)
-            page.get_by_role("button", name="認証する").click()
+            print(f"[{self.name}] メール認証コードをブラウザに入力して「認証する」を押してください（最大5分）")
             page.wait_for_url(
                 lambda url: "twofactorauth" not in url,
-                timeout=120000,
+                timeout=300_000,
             )
             _wait(2.0, 3.0)
 

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -36,6 +36,7 @@ e-delivery フィルター:
 from __future__ import annotations
 
 import argparse
+import sys
 import json
 import os
 from pathlib import Path
@@ -222,7 +223,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = SawakamiCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -89,7 +89,7 @@ class SawakamiCollector(BaseCollector):
             self.save_html(page, "after_credential_submit")
         else:
             print(f"[{self.name}] ログインID・パスワードをブラウザで入力してログインボタンを押してください")
-            input("ログインボタン押下後 Enter: ")
+            self.prompt("ログインボタン押下後 Enter: ")
 
         # twofactorauth か home のどちらかを待つ
         page.wait_for_url(
@@ -105,7 +105,7 @@ class SawakamiCollector(BaseCollector):
         # メール 2FA
         if "twofactorauth" in page.url:
             print(f"[{self.name}] メール認証コードを入力してください")
-            code = input("認証コード: ").strip()
+            code = self.prompt("認証コード: ").strip()
             page.get_by_role("spinbutton", name="認証コード").fill(code)
             page.get_by_role("button", name="認証する").click()
             page.wait_for_url(

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -237,10 +237,7 @@ class SawakamiCollector(BaseCollector):
                     year=year,
                     raw_files=[str(Path(pdf_path).name)],
                 )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
+                self._write_report_json(data)
             except Exception as e:
                 print(f"[{self.name}] JSON 変換スキップ: {e}")
 

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -43,7 +43,6 @@ from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://fv.sawakami.co.jp/Account/Login"
 _EDELIVERY_URL = "https://fv.sawakami.co.jp/e-delivery"
 
 from money_ops.utils import wait as _wait
@@ -75,7 +74,7 @@ class SawakamiCollector(BaseCollector):
           - GET  /account/twofactorauth?provider=Email&ReturnUrl=%2F&RememberMe=False
           - POST /account/twofactorauth?returnUrl=/ → 302 → /
         """
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -41,7 +41,6 @@ import os
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _EDELIVERY_URL = "https://fv.sawakami.co.jp/e-delivery"
@@ -213,18 +212,7 @@ class SawakamiCollector(BaseCollector):
             self.log_result("error", [], "PDF 取得失敗")
             return
 
-        try:
-            data = convert_pdf_to_json(
-                pdf_path=pdf_path,
-                company=self.name,
-                code=self.code,
-                year=year,
-                raw_files=[str(Path(pdf_path).name)],
-            )
-            self._write_report_json(data)
-        except Exception as e:
-            print(f"[{self.name}] JSON 変換スキップ: {e}")
-
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
         self.log_result("success", [pdf_path])
 
 def main() -> None:

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -214,44 +214,33 @@ class SawakamiCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
+    def _collect_core(self, page) -> None:
+        year = self.config.get("target_year")
+        if year is None:
+            raise ValueError("target_year が設定されていません")
+
+        if not self._is_logged_in(page):
+            self._login(page)
+
+        pdf_path = self._download_pdf(page, year)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 取得失敗")
+            return
+
         try:
-            year = self.config.get("target_year")
-            if year is None:
-                raise ValueError("target_year が設定されていません")
-
-            if not self._is_logged_in(page):
-                self._login(page)
-
-            pdf_path = self._download_pdf(page, year)
-            if pdf_path is None:
-                self.log_result("error", [], "PDF 取得失敗")
-                return
-
-            try:
-                data = convert_pdf_to_json(
-                    pdf_path=pdf_path,
-                    company=self.name,
-                    code=self.code,
-                    year=year,
-                    raw_files=[str(Path(pdf_path).name)],
-                )
-                self._write_report_json(data)
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ: {e}")
-
-            self.log_result("success", [pdf_path])
-
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
+            data = convert_pdf_to_json(
+                pdf_path=pdf_path,
+                company=self.name,
+                code=self.code,
+                year=year,
+                raw_files=[str(Path(pdf_path).name)],
+            )
+            self._write_report_json(data)
         except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
+            print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+        self.log_result("success", [pdf_path])
+
 
 
 def main() -> None:
@@ -259,7 +248,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = SawakamiCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/sawakami/collect.py
+++ b/skills/tax-collect/sites/sawakami/collect.py
@@ -56,11 +56,7 @@ from money_ops.utils import wait as _wait
 
 class SawakamiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/sawakami/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _is_logged_in(self, page) -> bool:
         """セッション有効チェック: /e-delivery にアクセスしてログイン済みか確認。

--- a/skills/tax-collect/sites/sawakami/site.json
+++ b/skills/tax-collect/sites/sawakami/site.json
@@ -1,10 +1,13 @@
 {
   "name": "さわかみ投信",
   "code": "sawakami",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/sawakami/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://fv.sawakami.co.jp/Account/Login",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -29,7 +29,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.sbisec.co.jp/ETGate"
 
 
-from money_ops.utils import extract_filename, wait as _wait
+from money_ops.collector.eshishobako import capture_dpaw_pdf
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:
@@ -92,47 +93,6 @@ class SBICollector(BaseCollector):
                 return btn.first
         return None
 
-    def _download_pdf_via_route(self, popup, output_dir: Path, fallback_name: str) -> str | None:
-        """context.route() で DPAW010501020 の PDF レスポンスを捕捉して保存
-        PDF ボタンクリック → blob URL ポップアップが開く → 閉じてから unroute（Rakuten と同方式）"""
-        pdf_btn = popup.locator("button, a").filter(has_text="PDFファイル")
-        if pdf_btn.count() == 0:
-            print(f"[{self.name}] PDF ボタンが見つかりません")
-            return None
-
-        pdf_bytes_holder: list[tuple[str, bytes]] = []
-
-        def _capture_pdf(route, _request) -> None:
-            response = route.fetch()
-            body = response.body()
-            if body[:4] == b"%PDF":
-                cd = response.headers.get("content-disposition", "")
-                m = _RE_FILENAME.search(cd)
-                filename = m.group(1).strip().strip('"\'') if m else fallback_name
-                pdf_bytes_holder.append((filename, body))
-            route.fulfill(response=response)
-
-        popup.context.route("**/DPAW010501020", _capture_pdf)
-        try:
-            with popup.expect_popup() as pdf_popup_info:
-                pdf_btn.first.click()
-            pdf_popup = pdf_popup_info.value
-            pdf_popup.wait_for_load_state("domcontentloaded")
-            _wait()
-            pdf_popup.close()  # ポップアップを閉じてからunroute（Rakuten方式）
-        finally:
-            popup.context.unroute("**/DPAW010501020", _capture_pdf)
-
-        if not pdf_bytes_holder:
-            print(f"[{self.name}] PDF レスポンスを捕捉できませんでした")
-            return None
-
-        filename, pdf_bytes = pdf_bytes_holder[0]
-        pdf_path = output_dir / filename
-        pdf_path.write_bytes(pdf_bytes)
-        print(f"[{self.name}] PDF 保存: {pdf_path}")
-        return str(pdf_path)
-
     def _download_files(self, popup) -> list[str]:
         self.prepare_directory()
         year = self.config["target_year"]
@@ -174,8 +134,8 @@ class SBICollector(BaseCollector):
             print(f"[{self.name}] XML ボタンが見つかりません")
 
         # PDF
-        pdf_path = self._download_pdf_via_route(
-            popup, self.output_dir, f"{year}_nentori.pdf"
+        pdf_path = capture_dpaw_pdf(
+            popup, self.output_dir, f"{year}_nentori.pdf", label=self.name
         )
         if pdf_path:
             downloaded.append(pdf_path)

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -52,6 +52,10 @@ class SBICollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)
+        page.wait_for_load_state("domcontentloaded")
+        if page.locator('input[name="username"]').count() == 0:
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            return
         print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください")
         input("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -40,7 +40,7 @@ class SBICollector(BaseCollector):
             self.save_html(page, "after_login_skip")
             return
         print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください")
-        input("トップ画面で操作可能になったら Enter を押してください: ")
+        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -55,10 +55,14 @@ class SBICollector(BaseCollector):
         page.wait_for_load_state("domcontentloaded")
         if page.locator('input[name="username"]').count() == 0:
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
+            self.save_html(page, "after_login_skip")
             return
         print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください")
         input("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()
+        self.dlog(f"URL: {page.url}")
+        self.save_html(page, "after_login")
         # ログイン直後にセッション状態（Cookie・デバイス登録情報）を明示的に保存
         page.context.storage_state(path=str(self._browser_profile_dir() / "storage_state.json"))
         print(f"[{self.name}] セッション状態を保存しました")
@@ -81,6 +85,8 @@ class SBICollector(BaseCollector):
         popup.wait_for_url("**/dp_apl/usr/**", timeout=30000)
         popup.wait_for_selector("input, button", timeout=30000)
         _wait(2.0, 3.0)
+        self.dlog(f"popup URL: {popup.url}")
+        self.save_html(popup, "report_popup")
         return popup
 
     def _find_report_row_button(self, popup, target_year: int):

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
@@ -151,7 +152,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = SBICollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -15,11 +15,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -31,7 +29,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.sbisec.co.jp/ETGate"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -32,17 +32,18 @@ class SBICollector(BaseCollector):
         super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
+        # ログイン完了 = site2.sbisec.co.jp 会員ドメイン到達。
+        # www.sbisec.co.jp/ETGate は公開トップ（未ログイン or セッション切れ）。
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
-        if page.locator('input[name="username"]').count() == 0:
+        _wait(1.5, 2.5)
+        if "site2.sbisec.co.jp" in page.url:
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             self.dlog(f"URL: {page.url}")
             self.save_html(page, "after_login_skip")
             return
         print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください（最大5分）")
-        page.wait_for_selector('input[name="username"]', state="detached", timeout=300_000)
-        # OTP等の多段認証後にダッシュボード到達まで待つ
-        page.wait_for_url("**/ETGate/**", timeout=300_000)
+        page.wait_for_url("**/site2.sbisec.co.jp/**", timeout=300_000)
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 
@@ -23,7 +22,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.sbisec.co.jp/ETGate"
@@ -143,25 +141,6 @@ class SBICollector(BaseCollector):
 
         return downloaded
 
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -173,7 +152,7 @@ class SBICollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -8,7 +8,7 @@
 
 注意:
     ログイン・2FA・ポップアップ処理は人間が手動で行う。
-    スクリプト起動後、ブラウザでトップ画面まで到達してから Enter を押すこと。
+    スクリプト起動後、ブラウザでログインしてください。トップ画面到達を自動検出します。
 """
 
 from __future__ import annotations
@@ -39,8 +39,8 @@ class SBICollector(BaseCollector):
             self.dlog(f"URL: {page.url}")
             self.save_html(page, "after_login_skip")
             return
-        print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください")
-        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください（最大5分）")
+        page.wait_for_selector('input[name="username"]', state="detached", timeout=300_000)
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -141,29 +141,18 @@ class SBICollector(BaseCollector):
 
         return downloaded
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            popup = self._navigate_to_report_popup(page)
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        popup = self._navigate_to_report_popup(page)
 
-            downloaded = self._download_files(popup)
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        downloaded = self._download_files(popup)
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -171,7 +160,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = SBICollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://www.sbisec.co.jp/ETGate"
 
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
@@ -33,7 +32,7 @@ class SBICollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         if page.locator('input[name="username"]').count() == 0:
             print(f"[{self.name}] ログイン済みを検出 → スキップ")

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -15,10 +15,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
@@ -33,8 +31,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.sbisec.co.jp/ETGate"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 def _year_month_patterns(target_year: int) -> list[str]:

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -41,6 +41,8 @@ class SBICollector(BaseCollector):
             return
         print(f"[{self.name}] ブラウザでログイン・OTP等をすべて完了してください（最大5分）")
         page.wait_for_selector('input[name="username"]', state="detached", timeout=300_000)
+        # OTP等の多段認証後にダッシュボード到達まで待つ
+        page.wait_for_url("**/ETGate/**", timeout=300_000)
         _wait()
         self.dlog(f"URL: {page.url}")
         self.save_html(page, "after_login")
@@ -54,6 +56,7 @@ class SBICollector(BaseCollector):
         page.get_by_role("link", name="口座管理").first.click(force=True)
         page.wait_for_load_state("domcontentloaded")
         _wait()
+        page.get_by_role("link", name="取引報告書等(電子交付)").first.wait_for(state="visible", timeout=60_000)
         page.get_by_role("link", name="取引報告書等(電子交付)").first.click(force=True)
         page.wait_for_load_state("domcontentloaded")
         _wait()

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -38,11 +38,7 @@ def _year_month_patterns(target_year: int) -> list[str]:
 
 class SBICollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/sbi/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -14,27 +14,19 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.sbisec.co.jp/ETGate"
 
-
 from money_ops.collector.eshishobako import capture_dpaw_pdf
 from money_ops.utils import wait as _wait
-
 
 def _year_month_patterns(target_year: int) -> list[str]:
     """発行年月の候補: 対象年12月 or 翌年1月"""
     return [f"{target_year}/12", f"{target_year + 1}/01"]
-
 
 class SBICollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -149,15 +141,12 @@ class SBICollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="SBI証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = SBICollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/sbi/collect.py
+++ b/skills/tax-collect/sites/sbi/collect.py
@@ -28,8 +28,8 @@ def _year_month_patterns(target_year: int) -> list[str]:
     return [f"{target_year}/12", f"{target_year + 1}/01"]
 
 class SBICollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -143,8 +143,10 @@ class SBICollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="SBI証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = SBICollector(year=args.year)
+    collector = SBICollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/sbi/site.json
+++ b/skills/tax-collect/sites/sbi/site.json
@@ -1,10 +1,13 @@
 {
   "name": "SBI証券",
   "code": "sbi",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/sbi/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.sbisec.co.jp/ETGate",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -28,8 +28,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 from money_ops.utils import extract_filename, wait as _wait
 
 class SMBCNikkoCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
         page.goto(self.config["login_url"])
@@ -196,8 +196,10 @@ class SMBCNikkoCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="SMBC日興証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = SMBCNikkoCollector(year=args.year)
+    collector = SMBCNikkoCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -32,17 +32,21 @@ class SMBCNikkoCollector(BaseCollector):
         super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _wait_for_login(self, page) -> None:
+        def _is_dashboard(url: str) -> bool:
+            return "trade.smbcnikko.co.jp" in url and "/Login/0/login/" not in url
+
         page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
-        url = page.url
-        if isinstance(url, str) and "trade.smbcnikko.co.jp" in url and "/Login/0/login/" not in url:
+        _wait(1.5, 2.5)
+        if _is_dashboard(page.url):
             print(f"[{self.name}] ログイン済みを検出 → スキップ")
             self._session = page
             self.save_html(self._session, "after_login_skip")
             return
+
         print(f"[{self.name}] ブラウザでログインしてください（ランダムキーパッド・OTP含む）（最大5分）")
         page.wait_for_url(
-            lambda url: "trade.smbcnikko.co.jp" in url and "/Login/0/login/" not in url,
+            lambda url: _is_dashboard(url),
             timeout=300_000,
         )
         _wait()
@@ -55,7 +59,8 @@ class SMBCNikkoCollector(BaseCollector):
         session = self._session
         print(f"[{self.name}] 各種お手続き → 電子交付サービス → 電子交付履歴 へ移動")
 
-        session.get_by_role("link", name="各種お手続き").click()
+        session.get_by_role("link", name="各種お手続き").first.wait_for(state="visible", timeout=60_000)
+        session.get_by_role("link", name="各種お手続き").first.click()
         session.wait_for_load_state("domcontentloaded")
         _wait()
         self.save_html(session, "after_otetsuzuki")

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -22,7 +22,6 @@ import sys
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
-_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
@@ -35,7 +34,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/"
 
 
-from money_ops.utils import wait as _wait
+from money_ops.utils import extract_filename, wait as _wait
 
 
 class SMBCNikkoCollector(BaseCollector):
@@ -169,10 +168,8 @@ class SMBCNikkoCollector(BaseCollector):
             return None
 
         cd = resp.headers.get("content-disposition", "")
-        m = _RE_FILENAME.search(cd)
-        if m:
-            filename = m.group(1).strip().strip('"\'')
-        else:
+        filename = extract_filename(cd)
+        if not filename:
             # SMBC日興は Content-Disposition なし → URL パスのファイル名を使用
             url_filename = Path(urlparse(pdf_url).path).name
             filename = url_filename if url_filename else f"{year}_nentori.pdf"

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -27,7 +26,6 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.xml_to_json import convert_teg204_xml
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 # 直接ログインフォームへ遷移（www.smbcnikko.co.jp 経由ポップアップは Playwright コンテキスト外になる）
@@ -178,25 +176,6 @@ class SMBCNikkoCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def _convert_to_json(self, downloaded_files: list[str]) -> None:
-        year = self.config["target_year"]
-        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
-        if not xml_files:
-            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
-            return
-        raw_files = [str(Path(f).name) for f in downloaded_files]
-        data = convert_teg204_xml(
-            xml_path=xml_files[0],
-            company=self.name,
-            code=self.code,
-            year=year,
-            raw_files=raw_files,
-        )
-        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        print(f"[{self.name}] JSON 保存: {json_path}")
-
     def collect(self) -> None:
         page = self.launch_browser()
         try:
@@ -225,7 +204,7 @@ class SMBCNikkoCollector(BaseCollector):
                 self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
                 return
 
-            self._convert_to_json(downloaded)
+            self._convert_xml_to_json(downloaded)
             self.log_result("success", downloaded)
 
         except KeyboardInterrupt:

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import re
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
@@ -208,7 +209,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = SMBCNikkoCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -9,7 +9,7 @@
 
 注意:
     ログイン・2FA・ランダムキーパッドは人間が手動で行う。
-    スクリプト起動後、ブラウザでトップ画面まで到達してから Enter を押すこと。
+    スクリプト起動後、ブラウザでログインしてください。トップ画面到達を自動検出します。
     XML ダウンロード時の取引パスワード入力も人間が行う（認証ボタンはスクリプトが押す）。
 """
 
@@ -40,8 +40,11 @@ class SMBCNikkoCollector(BaseCollector):
             self._session = page
             self.save_html(self._session, "after_login_skip")
             return
-        print(f"[{self.name}] ブラウザでログインしてください（ランダムキーパッド・OTP含む）")
-        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
+        print(f"[{self.name}] ブラウザでログインしてください（ランダムキーパッド・OTP含む）（最大5分）")
+        page.wait_for_url(
+            lambda url: "trade.smbcnikko.co.jp" in url and "/Login/0/login/" not in url,
+            timeout=300_000,
+        )
         _wait()
         self._session = page
         self.dlog(f"session URL: {self._session.url}")

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -200,6 +200,7 @@ class SMBCNikkoCollector(BaseCollector):
         page = self.launch_browser()
         try:
             self._wait_for_login(page)
+            self._save_session_state(page)
             session = self._session
             self._navigate_to_report_list()
             year = self.config["target_year"]

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -17,10 +17,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 import re
 import sys
-import time
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
@@ -37,8 +35,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class SMBCNikkoCollector(BaseCollector):

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -121,7 +121,7 @@ class SMBCNikkoCollector(BaseCollector):
 
         # 認証後は自動でダウンロードが始まる。expect_download で待機するだけ
         print(f"[{self.name}] ポップアップで取引パスワードを入力し「認証する」をクリックしてください")
-        with pw_popup.expect_download(timeout=120000) as dl_info:
+        with pw_popup.expect_download(timeout=300_000) as dl_info:
             pass
         dl = dl_info.value
         xml_path = self.output_dir / (dl.suggested_filename or f"{year}_nentori.xml")

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -41,7 +41,7 @@ class SMBCNikkoCollector(BaseCollector):
             self.save_html(self._session, "after_login_skip")
             return
         print(f"[{self.name}] ブラウザでログインしてください（ランダムキーパッド・OTP含む）")
-        input("トップ画面で操作可能になったら Enter を押してください: ")
+        self.prompt("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()
         self._session = page
         self.dlog(f"session URL: {self._session.url}")

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -24,7 +24,6 @@ from money_ops.collector.base import BaseCollector
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 # 直接ログインフォームへ遷移（www.smbcnikko.co.jp 経由ポップアップは Playwright コンテキスト外になる）
-_LOGIN_URL = "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/"
 
 from money_ops.utils import extract_filename, wait as _wait
 
@@ -33,7 +32,7 @@ class SMBCNikkoCollector(BaseCollector):
         super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         url = page.url
         if isinstance(url, str) and "trade.smbcnikko.co.jp" in url and "/Login/0/login/" not in url:

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -176,46 +176,35 @@ class SMBCNikkoCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
-        try:
-            self._wait_for_login(page)
-            self._save_session_state(page)
-            session = self._session
-            self._navigate_to_report_list()
-            year = self.config["target_year"]
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        self._save_session_state(page)
+        session = self._session
+        self._navigate_to_report_list()
+        year = self.config["target_year"]
 
-            if self._find_xml_link(session, year) is None:
-                self.log_result("skip", [], f"{year}年度の取引報告書が存在しません")
-                return
+        if self._find_xml_link(session, year) is None:
+            self.log_result("skip", [], f"{year}年度の取引報告書が存在しません")
+            return
 
-            self.prepare_directory()
-            downloaded: list[str] = []
+        self.prepare_directory()
+        downloaded: list[str] = []
 
-            xml_path = self._download_xml(session, year)
-            if xml_path:
-                downloaded.append(xml_path)
+        xml_path = self._download_xml(session, year)
+        if xml_path:
+            downloaded.append(xml_path)
 
-            pdf_path = self._download_pdf(session, year)
-            if pdf_path:
-                downloaded.append(pdf_path)
+        pdf_path = self._download_pdf(session, year)
+        if pdf_path:
+            downloaded.append(pdf_path)
 
-            if not downloaded:
-                self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
-                return
+        if not downloaded:
+            self.log_result("skip", [], "ダウンロード対象ファイルが見つかりませんでした")
+            return
 
-            self._convert_xml_to_json(downloaded)
-            self.log_result("success", downloaded)
+        self._convert_xml_to_json(downloaded)
+        self.log_result("success", downloaded)
 
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
-        except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
 
 
 def main() -> None:
@@ -223,7 +212,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = SMBCNikkoCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -51,6 +51,13 @@ class SMBCNikkoCollector(BaseCollector):
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)
+        page.wait_for_load_state("domcontentloaded")
+        url = page.url
+        if isinstance(url, str) and "trade.smbcnikko.co.jp" in url and "/Login/0/login/" not in url:
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self._session = page
+            self.save_html(self._session, "after_login_skip")
+            return
         print(f"[{self.name}] ブラウザでログインしてください（ランダムキーパッド・OTP含む）")
         input("トップ画面で操作可能になったら Enter を押してください: ")
         _wait()

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -17,13 +17,8 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 
@@ -31,9 +26,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 # 直接ログインフォームへ遷移（www.smbcnikko.co.jp 経由ポップアップは Playwright コンテキスト外になる）
 _LOGIN_URL = "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/"
 
-
 from money_ops.utils import extract_filename, wait as _wait
-
 
 class SMBCNikkoCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -201,15 +194,12 @@ class SMBCNikkoCollector(BaseCollector):
         self._convert_xml_to_json(downloaded)
         self.log_result("success", downloaded)
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="SMBC日興証券 年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None)
     args = parser.parse_args()
     collector = SMBCNikkoCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/smbcnikko/collect.py
+++ b/skills/tax-collect/sites/smbcnikko/collect.py
@@ -37,11 +37,7 @@ from money_ops.utils import extract_filename, wait as _wait
 
 class SMBCNikkoCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/smbcnikko/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _wait_for_login(self, page) -> None:
         page.goto(_LOGIN_URL)

--- a/skills/tax-collect/sites/smbcnikko/site.json
+++ b/skills/tax-collect/sites/smbcnikko/site.json
@@ -1,10 +1,13 @@
 {
   "name": "SMBC日興証券",
   "code": "smbcnikko",
-  "has_xml": true,
   "target_year": 2025,
   "output_dir": "data/income/securities/smbcnikko/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://trade.smbcnikko.co.jp/Login/0/login/ipan_web/hyoji/",
+  "converter_type": "teg204_xml"
 }

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -34,7 +34,6 @@ from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
-_LOGIN_URL = "https://www.tsumiki-sec.com/"
 
 from money_ops.utils import wait as _wait
 
@@ -50,7 +49,7 @@ class TsumikiCollector(BaseCollector):
           - エポスNet ID + パスワード入力 → ログインするボタン
           - ログイン後: 閉じるボタン（通知等）→ 以降の操作
         """
-        page.goto(_LOGIN_URL)
+        page.goto(self.config["login_url"])
         page.wait_for_load_state("domcontentloaded")
         _wait(1.5, 2.5)
 

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -10,8 +10,8 @@
     TSUMIKI_PASS    パスワード（未設定時は手動入力）
 
 注意:
-    ワンタイムパスワード（OTP）は必ず手動入力が必要。
-    OTP 送信後、メール/SMS に届いたコードを入力して Enter を押すこと。
+    ワンタイムパスワード（OTP）はブラウザで直接入力・送信してください。
+    スクリプトはブラウザの状態変化を自動検出します。
 
 実測済みページ構造:
     page:  tsumiki-sec.com トップ
@@ -70,8 +70,8 @@ class TsumikiCollector(BaseCollector):
             _wait(2.0, 3.0)
             print(f"[{self.name}] 自動ログイン完了")
         else:
-            print(f"[{self.name}] page1 でログインしてください（エポスNet ID・パスワード）")
-            self.prompt("ログイン完了後 Enter を押してください: ")
+            print(f"[{self.name}] page1 でログインしてください（エポスNet ID・パスワード）（最大5分）")
+            page1.wait_for_selector("button[name='ログインする']", state="detached", timeout=300_000)
             _wait(2.0, 3.0)
 
         # 通知等のダイアログを閉じる
@@ -116,13 +116,8 @@ class TsumikiCollector(BaseCollector):
         if otp_field.count() == 0:
             return True
 
-        print(f"[{self.name}] ワンタイムパスワードを入力してください（メール/SMSに届いたコード）")
-        otp = self.prompt("OTP コード: ").strip()
-        if not otp:
-            return False
-
-        otp_field.fill(otp)
-        page1.get_by_role("button", name="送信してすすむ").click()
+        print(f"[{self.name}] ワンタイムパスワードをブラウザに入力して「送信してすすむ」を押してください（最大5分）")
+        otp_field.wait_for(state="detached", timeout=300_000)
         _wait(2.0, 3.0)
         self.save_html(page1, "after_otp")
         return True

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -205,46 +205,35 @@ class TsumikiCollector(BaseCollector):
         print(f"[{self.name}] PDF 保存: {pdf_path}")
         return str(pdf_path)
 
-    def collect(self) -> None:
-        page = self.launch_browser()
+    def _collect_core(self, page) -> None:
+        page1 = self._login(page)
+        year = self.config["target_year"]
+
+        self._navigate_to_reports(page1)
+
+        if not self._handle_otp(page1):
+            self.log_result("skip", [], "OTP 入力がキャンセルされました")
+            return
+
+        pdf_path = self._download_pdf_via_route(page1, year)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 捕捉失敗")
+            return
+
         try:
-            page1 = self._login(page)
-            year = self.config["target_year"]
-
-            self._navigate_to_reports(page1)
-
-            if not self._handle_otp(page1):
-                self.log_result("skip", [], "OTP 入力がキャンセルされました")
-                return
-
-            pdf_path = self._download_pdf_via_route(page1, year)
-            if pdf_path is None:
-                self.log_result("error", [], "PDF 捕捉失敗")
-                return
-
-            try:
-                data = convert_pdf_to_json(
-                    pdf_path=pdf_path,
-                    company=self.name,
-                    code=self.code,
-                    year=year,
-                    raw_files=[str(Path(pdf_path).name)],
-                )
-                self._write_report_json(data)
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ: {e}")
-
-            self.log_result("success", [pdf_path])
-
-        except KeyboardInterrupt:
-            print(f"\n[{self.name}] ユーザーによる中断")
-            self.log_result("interrupted", [], "ユーザーによる中断")
+            data = convert_pdf_to_json(
+                pdf_path=pdf_path,
+                company=self.name,
+                code=self.code,
+                year=year,
+                raw_files=[str(Path(pdf_path).name)],
+            )
+            self._write_report_json(data)
         except Exception as e:
-            print(f"[{self.name}] エラー: {e}")
-            self.log_result("error", [], str(e))
-            raise
-        finally:
-            self.close_browser()
+            print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+        self.log_result("success", [pdf_path])
+
 
 
 def main() -> None:
@@ -252,7 +241,7 @@ def main() -> None:
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = TsumikiCollector(year=args.year)
-    collector.collect()
+    collector.run()
 
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -38,8 +38,8 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 from money_ops.utils import wait as _wait
 
 class TsumikiCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _login(self, page) -> object:
         """tsumiki-sec.com → ログインリンク → popup page1（omamori SPA）。
@@ -226,8 +226,10 @@ class TsumikiCollector(BaseCollector):
 def main() -> None:
     parser = argparse.ArgumentParser(description="tsumiki証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = TsumikiCollector(year=args.year)
+    collector = TsumikiCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.run()
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -28,10 +28,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import random
 import re
 import sys
-import time
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
@@ -44,8 +42,7 @@ _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.tsumiki-sec.com/"
 
 
-def _wait(lo: float = 1.0, hi: float = 3.0) -> None:
-    time.sleep(random.uniform(lo, hi))
+from money_ops.utils import wait as _wait
 
 
 class TsumikiCollector(BaseCollector):

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -26,6 +26,7 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
+import sys
 import os
 import re
 from pathlib import Path
@@ -124,14 +125,14 @@ class TsumikiCollector(BaseCollector):
     def _find_report_button(self, page1, target_year: int):
         """特定口座年間取引報告書ボタンを年度で検索。
 
-        HAR 確認済み: ボタン名 = 「特定口座年間取引報告書 作成日 YYYY/MM/DD」
+        HAR 確認済み: 実 DOM は <div role="button" aria-label="特定口座年間取引報告書　作成日　YYYY/MM/DD　既読　報告書を新しいタブで開く">
+        → locator("a, button") では拾えない。get_by_role("button") なら role=button の div もマッチ。
+        作成年度 = target_year+1 （例: 2025年度の報告書は 2026/01/01 作成）。
         """
-        base = page1.locator("a, button")
-        btn = base.filter(has_text=re.compile(r"特定口座年間取引報告書")).filter(
-            has_text=re.compile(str(target_year + 1))
-        )
+        # まず作成年度 (target_year+1) で絞り込み、無ければ年度なしで検索
+        btn = page1.get_by_role("button", name=re.compile(rf"特定口座年間取引報告書.*{target_year + 1}"))
         if btn.count() == 0:
-            btn = base.filter(has_text=re.compile(r"特定口座年間取引報告書"))
+            btn = page1.get_by_role("button", name=re.compile(r"特定口座年間取引報告書"))
         return btn.first if btn.count() > 0 else None
 
     def _download_pdf_via_route(self, page1, target_year: int) -> str | None:
@@ -210,7 +211,6 @@ def main() -> None:
     parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
     collector = TsumikiCollector(year=args.year, headless=args.headless, debug=args.debug)
-    collector.run()
-
+    sys.exit(collector.run())
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -31,7 +31,6 @@ import re
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 
@@ -127,15 +126,12 @@ class TsumikiCollector(BaseCollector):
 
         HAR 確認済み: ボタン名 = 「特定口座年間取引報告書 作成日 YYYY/MM/DD」
         """
-        btn = page1.get_by_role("button").filter(
-            has_text=re.compile(r"特定口座年間取引報告書")
-        ).filter(
+        base = page1.locator("a, button")
+        btn = base.filter(has_text=re.compile(r"特定口座年間取引報告書")).filter(
             has_text=re.compile(str(target_year + 1))
         )
         if btn.count() == 0:
-            btn = page1.get_by_role("button").filter(
-                has_text=re.compile(r"特定口座年間取引報告書")
-            )
+            btn = base.filter(has_text=re.compile(r"特定口座年間取引報告書"))
         return btn.first if btn.count() > 0 else None
 
     def _download_pdf_via_route(self, page1, target_year: int) -> str | None:
@@ -204,18 +200,7 @@ class TsumikiCollector(BaseCollector):
             self.log_result("error", [], "PDF 捕捉失敗")
             return
 
-        try:
-            data = convert_pdf_to_json(
-                pdf_path=pdf_path,
-                company=self.name,
-                code=self.code,
-                year=year,
-                raw_files=[str(Path(pdf_path).name)],
-            )
-            self._write_report_json(data)
-        except Exception as e:
-            print(f"[{self.name}] JSON 変換スキップ: {e}")
-
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
         self.log_result("success", [pdf_path])
 
 def main() -> None:

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -71,7 +71,7 @@ class TsumikiCollector(BaseCollector):
             print(f"[{self.name}] 自動ログイン完了")
         else:
             print(f"[{self.name}] page1 でログインしてください（エポスNet ID・パスワード）（最大5分）")
-            page1.wait_for_selector("button[name='ログインする']", state="detached", timeout=300_000)
+            page1.get_by_role("button", name="ログインする").first.wait_for(state="detached", timeout=300_000)
             _wait(2.0, 3.0)
 
         # 通知等のダイアログを閉じる

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -71,7 +71,7 @@ class TsumikiCollector(BaseCollector):
             print(f"[{self.name}] 自動ログイン完了")
         else:
             print(f"[{self.name}] page1 でログインしてください（エポスNet ID・パスワード）")
-            input("ログイン完了後 Enter を押してください: ")
+            self.prompt("ログイン完了後 Enter を押してください: ")
             _wait(2.0, 3.0)
 
         # 通知等のダイアログを閉じる
@@ -117,7 +117,7 @@ class TsumikiCollector(BaseCollector):
             return True
 
         print(f"[{self.name}] ワンタイムパスワードを入力してください（メール/SMSに届いたコード）")
-        otp = input("OTP コード: ").strip()
+        otp = self.prompt("OTP コード: ").strip()
         if not otp:
             return False
 

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -26,7 +26,6 @@ PDF取得方式:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -231,10 +230,7 @@ class TsumikiCollector(BaseCollector):
                     year=year,
                     raw_files=[str(Path(pdf_path).name)],
                 )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
+                self._write_report_json(data)
             except Exception as e:
                 print(f"[{self.name}] JSON 変換スキップ: {e}")
 

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -46,11 +46,7 @@ from money_ops.utils import wait as _wait
 
 class TsumikiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/tsumiki/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _login(self, page) -> object:
         """tsumiki-sec.com → ログインリンク → popup page1（omamori SPA）。

--- a/skills/tax-collect/sites/tsumiki/collect.py
+++ b/skills/tax-collect/sites/tsumiki/collect.py
@@ -28,11 +28,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
-import sys
 from pathlib import Path
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
@@ -40,9 +36,7 @@ from money_ops.converter.pdf_to_json import convert_pdf_to_json
 _SITE_JSON = Path(__file__).parent / "site.json"
 _LOGIN_URL = "https://www.tsumiki-sec.com/"
 
-
 from money_ops.utils import wait as _wait
-
 
 class TsumikiCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -230,15 +224,12 @@ class TsumikiCollector(BaseCollector):
 
         self.log_result("success", [pdf_path])
 
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="tsumiki証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     args = parser.parse_args()
     collector = TsumikiCollector(year=args.year)
     collector.run()
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/tsumiki/site.json
+++ b/skills/tax-collect/sites/tsumiki/site.json
@@ -1,10 +1,13 @@
 {
   "name": "tsumiki証券",
   "code": "tsumiki",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/tsumiki/2025/raw/",
   "documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.tsumiki-sec.com/",
+  "converter_type": "pdf_llm"
 }

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -42,11 +43,7 @@ _PACKAGE = "org.dayup.stocks.jp"
 _DOCS_DIR = "/sdcard/Documents"
 _TARGET_DOC = "特定口座年間取引報告書"
 
-_ADB_FALLBACK = Path(
-    r"C:\Users\g\AppData\Local\Microsoft\WinGet\Packages"
-    r"\Google.PlatformTools_Microsoft.Winget.Source_8wekyb3d8bbwe"
-    r"\platform-tools\adb.exe"
-)
+_ADB_FALLBACK = Path(os.environ["ADB_PATH"]) if os.environ.get("ADB_PATH") else None
 
 
 def _adb(*args: str) -> str:
@@ -56,13 +53,13 @@ def _adb(*args: str) -> str:
             cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
         )
     except FileNotFoundError:
-        if _ADB_FALLBACK.exists():
+        if _ADB_FALLBACK is not None and _ADB_FALLBACK.exists():
             cmd[0] = str(_ADB_FALLBACK)
             result = subprocess.run(
                 cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
             )
         else:
-            raise RuntimeError("adb が見つかりません。PATH に追加してください（README_ADB.md 参照）")
+            raise RuntimeError("adb が見つかりません。PATH に追加するか ADB_PATH 環境変数を設定してください")
     return result.stdout.strip()
 
 

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -96,7 +96,7 @@ class WebullCollector(BaseCollector):
         hyohyo_tab = d(resourceId=f"{_PACKAGE}:id/tabTitle", text="帳票")
         if not hyohyo_tab.exists:
             print(f"[{self.name}] 認証が必要です。アプリでログインして帳票タブが表示されたら Enter を押してください")
-            input("Enter: ")
+            self.prompt("Enter: ")
             _wait(1.0)
             hyohyo_tab = d(resourceId=f"{_PACKAGE}:id/tabTitle", text="帳票")
             if not hyohyo_tab.exists:

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -69,11 +69,7 @@ def _wait(t: float = 1.5) -> None:
 
 class WebullCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path)
-        if year is not None:
-            self.config["target_year"] = year
-            self.config["output_dir"] = f"data/income/securities/webull/{year}/raw/"
-            self.output_dir = Path(self.config["output_dir"])
+        super().__init__(site_json_path, year)
 
     def _list_dir(self, remote_dir: str) -> set[str]:
         out = _adb("shell", "ls", remote_dir)

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -36,6 +36,7 @@ from pathlib import Path
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 
+from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
@@ -67,16 +68,13 @@ def _wait(t: float = 1.5) -> None:
     time.sleep(t)
 
 
-class WebullCollector:
+class WebullCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        with open(site_json_path, encoding="utf-8") as f:
-            self.config = json.load(f)
-        self.name: str = self.config["name"]
-        self.code: str = self.config["code"]
+        super().__init__(site_json_path)
         if year is not None:
             self.config["target_year"] = year
             self.config["output_dir"] = f"data/income/securities/webull/{year}/raw/"
-        self.output_dir = _PROJECT_ROOT / self.config["output_dir"]
+            self.output_dir = Path(self.config["output_dir"])
 
     def _list_dir(self, remote_dir: str) -> set[str]:
         out = _adb("shell", "ls", remote_dir)
@@ -165,106 +163,118 @@ class WebullCollector:
         try:
             import uiautomator2 as u2
         except ImportError:
-            print(f"[{self.name}] uiautomator2 未インストール: pip install uiautomator2")
+            self.log_result("error", [], "uiautomator2 未インストール: pip install uiautomator2")
             sys.exit(1)
 
         target_year = self.config.get("target_year")
         if target_year is None:
+            self.log_result("error", [], "target_year が設定されていません")
             raise ValueError("target_year が設定されていません")
 
-        if serial is None:
-            serial = self._find_adb_serial()
-
-        d = u2.connect(serial)
-        print(f"[{self.name}] デバイス接続: {d.serial}")
-
         try:
-            self._launch_app(d)
-            self._navigate_to_history(d)
+            if serial is None:
+                serial = self._find_adb_serial()
 
-            files_before = self._snapshot()
-
-            print(f"[{self.name}] {_TARGET_DOC} ({target_year}) を検索中...")
-            if not self._find_and_tap_doc(d, target_year):
-                print(f"[{self.name}] {_TARGET_DOC} ({target_year}) が見つかりません")
-                return
-
-            # WebView 読み込み待ち
-            _wait(3.0)
-            webview = d(resourceId=f"{_PACKAGE}:id/webview")
-            if not webview.wait(timeout=15):
-                print(f"[{self.name}] WebView タイムアウト")
-                return
-            _wait(2.0)
-
-            # ダウンロードボタン（r2_menu_icon）
-            dl_btn = d(resourceId=f"{_PACKAGE}:id/r2_menu_icon")
-            if not dl_btn.exists:
-                print(f"[{self.name}] ダウンロードボタンが見つかりません")
-                return
-            dl_btn.click()
-
-            # フォルダ権限ダイアログ（初回のみ・2段階）: 最大10秒待ちながら検出→タップ
-            for _ in range(10):
-                _wait(1.0)
-                for btn_text in ["このフォルダを使用", "許可", "ALLOW", "Allow"]:
-                    btn = d(text=btn_text)
-                    if btn.exists:
-                        print(f"[{self.name}] 権限ダイアログ「{btn_text}」→ タップ")
-                        btn.click()
-                        _wait(0.5)
-
-            _wait(4.0)
-
-            # 新規ファイル特定（Documents と Download 両方チェック）
-            new_files = self._snapshot() - files_before
-            print(f"[{self.name}] 新規ファイル: {new_files or '(なし)'}")
-
-            if not new_files:
-                print(f"[{self.name}] ダウンロードファイルが見つかりません")
-                return
-            if len(new_files) > 1:
-                print(f"[{self.name}] 警告: 複数の新規ファイル: {new_files}")
-
-            remote_path = next(iter(new_files))
-
-            self.output_dir.mkdir(parents=True, exist_ok=True)
-            local_path = self.output_dir / f"{target_year}_webull_nentori.pdf"
-
-            print(f"[{self.name}] adb pull: {remote_path} → {local_path}")
-            _adb("pull", remote_path, str(local_path))
-
-            if not local_path.exists() or local_path.stat().st_size == 0:
-                print(f"[{self.name}] pull 失敗")
-                return
-
-            if local_path.read_bytes()[:4] != b"%PDF":
-                print(f"[{self.name}] PDF 検証失敗")
-                local_path.unlink(missing_ok=True)
-                return
-
-            print(f"[{self.name}] PDF 保存: {local_path}")
+            d = u2.connect(serial)
+            print(f"[{self.name}] デバイス接続: {d.serial}")
 
             try:
-                data = convert_pdf_to_json(
-                    pdf_path=str(local_path),
-                    company=self.name,
-                    code=self.code,
-                    year=target_year,
-                    raw_files=[local_path.name],
-                )
-                json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                with open(json_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-                print(f"[{self.name}] JSON 保存: {json_path}")
-            except Exception as e:
-                print(f"[{self.name}] JSON 変換スキップ: {e}")
+                self._launch_app(d)
+                self._navigate_to_history(d)
 
-            print(f"[{self.name}] 完了")
+                files_before = self._snapshot()
 
-        finally:
-            _adb("shell", "am", "force-stop", _PACKAGE)
-            print(f"[{self.name}] アプリ終了")
+                print(f"[{self.name}] {_TARGET_DOC} ({target_year}) を検索中...")
+                if not self._find_and_tap_doc(d, target_year):
+                    self.log_result("skip", [], f"{_TARGET_DOC} ({target_year}) が見つかりません")
+                    return
+
+                # WebView 読み込み待ち
+                _wait(3.0)
+                webview = d(resourceId=f"{_PACKAGE}:id/webview")
+                if not webview.wait(timeout=15):
+                    self.log_result("skip", [], "WebView タイムアウト")
+                    return
+                _wait(2.0)
+
+                # ダウンロードボタン（r2_menu_icon）
+                dl_btn = d(resourceId=f"{_PACKAGE}:id/r2_menu_icon")
+                if not dl_btn.exists:
+                    self.log_result("skip", [], "ダウンロードボタンが見つかりません")
+                    return
+                dl_btn.click()
+
+                # フォルダ権限ダイアログ（初回のみ・2段階）: 最大10秒待ちながら検出→タップ
+                for _ in range(10):
+                    _wait(1.0)
+                    for btn_text in ["このフォルダを使用", "許可", "ALLOW", "Allow"]:
+                        btn = d(text=btn_text)
+                        if btn.exists:
+                            print(f"[{self.name}] 権限ダイアログ「{btn_text}」→ タップ")
+                            btn.click()
+                            _wait(0.5)
+
+                _wait(4.0)
+
+                # 新規ファイル特定（Documents と Download 両方チェック）
+                new_files = self._snapshot() - files_before
+                print(f"[{self.name}] 新規ファイル: {new_files or '(なし)'}")
+
+                if not new_files:
+                    self.log_result("skip", [], "ダウンロードファイルが見つかりません")
+                    return
+                if len(new_files) > 1:
+                    print(f"[{self.name}] 警告: 複数の新規ファイル: {new_files}")
+
+                remote_path = next(iter(new_files))
+
+                self.output_dir.mkdir(parents=True, exist_ok=True)
+                local_path = self.output_dir / f"{target_year}_webull_nentori.pdf"
+
+                print(f"[{self.name}] adb pull: {remote_path} → {local_path}")
+                _adb("pull", remote_path, str(local_path))
+
+                if not local_path.exists() or local_path.stat().st_size == 0:
+                    self.log_result("error", [], "adb pull 失敗")
+                    return
+
+                if local_path.read_bytes()[:4] != b"%PDF":
+                    self.log_result("error", [], "PDF 検証失敗")
+                    local_path.unlink(missing_ok=True)
+                    return
+
+                print(f"[{self.name}] PDF 保存: {local_path}")
+
+                json_ok = False
+                try:
+                    data = convert_pdf_to_json(
+                        pdf_path=str(local_path),
+                        company=self.name,
+                        code=self.code,
+                        year=target_year,
+                        raw_files=[local_path.name],
+                    )
+                    json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
+                    with open(json_path, "w", encoding="utf-8") as f:
+                        json.dump(data, f, ensure_ascii=False, indent=2)
+                    print(f"[{self.name}] JSON 保存: {json_path}")
+                    json_ok = True
+                except Exception as e:
+                    print(f"[{self.name}] JSON 変換スキップ: {e}")
+
+                if json_ok:
+                    self.log_result("success", [str(local_path)])
+                else:
+                    self.log_result("error", [str(local_path)], "JSON 変換失敗")
+
+            finally:
+                _adb("shell", "am", "force-stop", _PACKAGE)
+                print(f"[{self.name}] アプリ終了")
+
+        except Exception as e:
+            print(f"[{self.name}] エラー: {e}")
+            self.log_result("error", [], str(e))
+            raise
 
 
 def main() -> None:

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -32,9 +32,6 @@ import sys
 import time
 from pathlib import Path
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(_PROJECT_ROOT / "src"))
-
 from money_ops.collector.base import BaseCollector
 from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
@@ -44,7 +41,6 @@ _DOCS_DIR = "/sdcard/Documents"
 _TARGET_DOC = "特定口座年間取引報告書"
 
 _ADB_FALLBACK = Path(os.environ["ADB_PATH"]) if os.environ.get("ADB_PATH") else None
-
 
 def _adb(*args: str) -> str:
     cmd = ["adb", *args]
@@ -62,10 +58,8 @@ def _adb(*args: str) -> str:
             raise RuntimeError("adb が見つかりません。PATH に追加するか ADB_PATH 環境変数を設定してください")
     return result.stdout.strip()
 
-
 def _wait(t: float = 1.5) -> None:
     time.sleep(t)
-
 
 class WebullCollector(BaseCollector):
     def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
@@ -268,7 +262,6 @@ class WebullCollector(BaseCollector):
             self.log_result("error", [], str(e))
             raise
 
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="ウィブル証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
@@ -276,7 +269,6 @@ def main() -> None:
     args = parser.parse_args()
     collector = WebullCollector(year=args.year)
     collector.collect(serial=args.serial)
-
 
 if __name__ == "__main__":
     main()

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -33,7 +33,6 @@ import time
 from pathlib import Path
 
 from money_ops.collector.base import BaseCollector
-from money_ops.converter.pdf_to_json import convert_pdf_to_json
 
 _SITE_JSON = Path(__file__).parent / "site.json"
 _PACKAGE = "org.dayup.stocks.jp"
@@ -92,15 +91,12 @@ class WebullCollector(BaseCollector):
             trade_btn.click()
             _wait(2.0)
 
-        # 帳票タブが見つからない場合は認証が必要 → 手動ログイン待ち
+        # 帳票タブが見つからない場合は認証が必要 → 出現を最大10分待機
         hyohyo_tab = d(resourceId=f"{_PACKAGE}:id/tabTitle", text="帳票")
         if not hyohyo_tab.exists:
-            print(f"[{self.name}] 認証が必要です。アプリでログインして帳票タブが表示されたら Enter を押してください")
-            self.prompt("Enter: ")
-            _wait(1.0)
-            hyohyo_tab = d(resourceId=f"{_PACKAGE}:id/tabTitle", text="帳票")
-            if not hyohyo_tab.exists:
-                raise RuntimeError(f"[{self.name}] 帳票タブが見つかりません")
+            print(f"[{self.name}] 認証が必要です。アプリでログインしてください（帳票タブ出現まで最大10分待機）")
+            if not hyohyo_tab.wait(timeout=600):
+                raise RuntimeError(f"[{self.name}] 帳票タブが見つかりません（10分タイムアウト）")
 
         # 帳票タブ（タブバーの「履歴」ではなく「帳票」）
         hyohyo_tab.click()
@@ -135,17 +131,39 @@ class WebullCollector(BaseCollector):
             _wait(1.0)
         return False
 
-    def _find_adb_serial(self) -> str:
-        """adb devices から接続済みデバイスのシリアルを返す。見つからなければ例外。"""
-        out = _adb("devices")
-        for line in out.splitlines()[1:]:
-            parts = line.strip().split()
-            if len(parts) == 2 and parts[1] == "device":
-                return parts[0]
+    def _find_adb_serial(self, max_wait_sec: int = 30) -> str:
+        """adb server 起動 → USB接続デバイス検出をリトライ。
+        `device`(ready) を検出したら serial 返却。
+        `unauthorized`(USBデバッグ承認待ち) / `offline` 中は進捗ログ出してリトライ。
+        max_wait_sec 経過で例外。
+        """
+        _adb("start-server")
+        deadline = time.time() + max_wait_sec
+        last_log = ""
+        while time.time() < deadline:
+            out = _adb("devices")
+            states: dict[str, str] = {}
+            for line in out.splitlines()[1:]:
+                parts = line.strip().split()
+                if len(parts) == 2:
+                    states[parts[0]] = parts[1]
+            for serial, state in states.items():
+                if state == "device":
+                    print(f"[{self.name}] ADB デバイス検出: {serial}")
+                    return serial
+            if any(s == "unauthorized" for s in states.values()):
+                msg = "USBデバッグ承認待ち（端末で許可ダイアログをタップ）"
+            elif any(s == "offline" for s in states.values()):
+                msg = "adb offline → 再接続待ち"
+            else:
+                msg = "ADB デバイス未検出 → USB接続待ち"
+            if msg != last_log:
+                print(f"[{self.name}] {msg}")
+                last_log = msg
+            time.sleep(2.0)
         raise RuntimeError(
-            "ADB デバイスが見つかりません。\n"
-            "先に以下を実行してください（ポートはワイヤレスデバッグ画面で確認）:\n"
-            "  adb connect <AndroidのIP>:<ポート番号>"
+            f"[{self.name}] ADB デバイス検出タイムアウト（{max_wait_sec}秒）。\n"
+            "確認: USBケーブル接続 / 端末で USBデバッグ 有効 / 端末ロック解除"
         )
 
     def collect(self, serial: str | None = None) -> None:
@@ -234,24 +252,8 @@ class WebullCollector(BaseCollector):
 
                 print(f"[{self.name}] PDF 保存: {local_path}")
 
-                json_ok = False
-                try:
-                    data = convert_pdf_to_json(
-                        pdf_path=str(local_path),
-                        company=self.name,
-                        code=self.code,
-                        year=target_year,
-                        raw_files=[local_path.name],
-                    )
-                    self._write_report_json(data)
-                    json_ok = True
-                except Exception as e:
-                    print(f"[{self.name}] JSON 変換スキップ: {e}")
-
-                if json_ok:
-                    self.log_result("success", [str(local_path)])
-                else:
-                    self.log_result("error", [str(local_path)], "JSON 変換失敗")
+                self._queue_pdf_to_json(str(local_path), [local_path.name])
+                self.log_result("success", [str(local_path)])
 
             finally:
                 _adb("shell", "am", "force-stop", _PACKAGE)

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -26,7 +26,6 @@ UI 構造（uiautomator dump 確認済み）:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -254,10 +253,7 @@ class WebullCollector(BaseCollector):
                         year=target_year,
                         raw_files=[local_path.name],
                     )
-                    json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
-                    with open(json_path, "w", encoding="utf-8") as f:
-                        json.dump(data, f, ensure_ascii=False, indent=2)
-                    print(f"[{self.name}] JSON 保存: {json_path}")
+                    self._write_report_json(data)
                     json_ok = True
                 except Exception as e:
                     print(f"[{self.name}] JSON 変換スキップ: {e}")

--- a/skills/tax-collect/sites/webull/collect.py
+++ b/skills/tax-collect/sites/webull/collect.py
@@ -62,8 +62,8 @@ def _wait(t: float = 1.5) -> None:
     time.sleep(t)
 
 class WebullCollector(BaseCollector):
-    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None):
-        super().__init__(site_json_path, year)
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
 
     def _list_dir(self, remote_dir: str) -> set[str]:
         out = _adb("shell", "ls", remote_dir)
@@ -266,8 +266,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="ウィブル証券 特定口座年間取引報告書収集")
     parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
     parser.add_argument("--serial", default=None, help="ADB デバイスシリアル（省略時: adb devices から自動取得）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
     args = parser.parse_args()
-    collector = WebullCollector(year=args.year)
+    collector = WebullCollector(year=args.year, headless=args.headless, debug=args.debug)
     collector.collect(serial=args.serial)
 
 if __name__ == "__main__":

--- a/skills/tax-collect/sites/webull/site.json
+++ b/skills/tax-collect/sites/webull/site.json
@@ -1,10 +1,12 @@
 {
   "name": "ウィブル証券",
   "code": "webull",
-  "has_xml": false,
   "target_year": 2025,
   "output_dir": "data/income/securities/webull/2025/raw/",
-"documents": [
-    { "type": "特定口座年間取引報告書" }
-  ]
+  "documents": [
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "converter_type": "pdf_llm"
 }

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -48,6 +48,18 @@ class BaseCollector:
         d.mkdir(parents=True, exist_ok=True)
         return d
 
+    def _log_access(self, url: str) -> None:
+        """debug モード時のみ全ナビゲーションを output/debug/<code>/access.log に追記"""
+        if not self.debug:
+            return
+        try:
+            log_path = self._debug_dir() / "access.log"
+            ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(f"{ts} {url}\n")
+        except Exception:
+            pass
+
     def prompt(self, message: str) -> str:
         """ユーザーへの入力要求。将来的に並列収集用 EnvPrompt で差し替え可能。"""
         return input(message)
@@ -117,7 +129,15 @@ class BaseCollector:
         )
         self._page = self._context.new_page()
         self._restore_session_cookies()
+        # 全ページのナビゲーションをアクセスログに記録
+        self._context.on("page", self._attach_access_logger)
+        self._attach_access_logger(self._page)
         return self._page
+
+    def _attach_access_logger(self, page) -> None:
+        page.on("framenavigated", lambda frame: (
+            self._log_access(frame.url) if frame == frame.page.main_frame else None
+        ))
 
     def _restore_session_cookies(self) -> None:
         """前回ログイン時に保存した storage_state.json から全 cookie を注入する。

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -42,6 +42,10 @@ class BaseCollector:
         d.mkdir(parents=True, exist_ok=True)
         return d
 
+    def prompt(self, message: str) -> str:
+        """ユーザーへの入力要求。将来的に並列収集用 EnvPrompt で差し替え可能。"""
+        return input(message)
+
     def dlog(self, message: str) -> None:
         """DEBUG=true のときだけ出力する詳細ログ"""
         if self.debug:

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -1,7 +1,11 @@
 import json
 import os
+import sys
+import time
 from datetime import datetime
 from pathlib import Path
+
+_SIGNAL_DIR = Path(".")  # プロジェクトルートから実行前提
 
 try:
     from dotenv import load_dotenv as _load_dotenv
@@ -49,8 +53,24 @@ class BaseCollector:
         return d
 
     def prompt(self, message: str) -> str:
-        """ユーザーへの入力要求。将来的に並列収集用 EnvPrompt で差し替え可能。"""
-        return input(message)
+        """ユーザーへの入力要求。
+        TTY接続時: input()で待機（ターミナル直接実行）
+        非TTY時: .waiting_<code> / .signal_<code> ファイル経由で待機（Bashツール経由）
+        """
+        if sys.stdin.isatty():
+            return input(message)
+        waiting = _SIGNAL_DIR / f".waiting_{self.code}"
+        signal = _SIGNAL_DIR / f".signal_{self.code}"
+        signal.unlink(missing_ok=True)
+        waiting.write_text(message, encoding="utf-8")
+        print(f"[{self.name}] 待機中（signal: {signal}）", flush=True)
+        try:
+            while not signal.exists():
+                time.sleep(0.5)
+        finally:
+            waiting.unlink(missing_ok=True)
+        signal.unlink(missing_ok=True)
+        return ""
 
     def dlog(self, message: str) -> None:
         """DEBUG=true のときだけ出力する詳細ログ"""

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -113,8 +113,12 @@ class BaseCollector:
         state_path = self._browser_profile_dir() / "storage_state.json"
         if not state_path.exists():
             return
-        with open(state_path, encoding="utf-8") as f:
-            state = json.load(f)
+        try:
+            with open(state_path, encoding="utf-8") as f:
+                state = json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"[{self.name}] storage_state.json が破損しています（スキップ）: {e}")
+            return
         cookies = state.get("cookies", [])
         if not cookies:
             return
@@ -152,6 +156,22 @@ class BaseCollector:
             json.dump(history, f, ensure_ascii=False, indent=2)
 
         print(f"[{self.name}] {status}: {message or ', '.join(files)}")
+
+    def _save_session_state(self, page) -> None:
+        """cookie が存在する場合のみ storage_state.json を保存（空書き込みで既存 cookie 喪失を防ぐ）。
+        atomic write で書き込み中断時の JSON 破損を防ぐ。"""
+        state = page.context.storage_state()
+        if not state.get("cookies"):
+            self.dlog("storage_state が空のため保存スキップ")
+            return
+        profile_dir = self._browser_profile_dir()
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        state_path = profile_dir / "storage_state.json"
+        tmp_path = state_path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(state, f, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, state_path)
+        print(f"[{self.name}] セッション保存: {state_path} ({len(state['cookies'])} cookies)")
 
     def verify_pdf(self, pdf_path: str | Path) -> bool:
         """PDF ファイルの存在・非空・マジックバイト（%PDF）を検証する。"""

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -24,7 +24,7 @@ def _is_debug() -> bool:
 
 
 class BaseCollector:
-    def __init__(self, site_json_path: str | Path):
+    def __init__(self, site_json_path: str | Path, year: int | None = None):
         self.config = _load_site_config(site_json_path)
         self.code: str = self.config["code"]
         self.name: str = self.config["name"]
@@ -32,6 +32,10 @@ class BaseCollector:
         self.headless: bool = _is_headless()
         self.debug: bool = _is_debug()
         self._debug_seq: int = 0  # HTML採取連番
+        if year is not None:
+            self.config["target_year"] = year
+            self.config["output_dir"] = f"data/income/securities/{self.code}/{year}/raw/"
+            self.output_dir = Path(self.config["output_dir"])
 
     def _debug_dir(self) -> Path:
         d = Path("output") / "debug" / self.code

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -215,5 +215,19 @@ class BaseCollector:
         )
         self._write_report_json(data)
 
-    def collect(self) -> None:
-        raise NotImplementedError("collect() をサブクラスで実装してください")
+    def _collect_core(self, page) -> None:
+        raise NotImplementedError("_collect_core() をサブクラスで実装してください")
+
+    def run(self) -> None:
+        page = self.launch_browser()
+        try:
+            self._collect_core(page)
+        except KeyboardInterrupt:
+            print(f"\n[{self.name}] ユーザーによる中断")
+            self.log_result("interrupted", [], "ユーザーによる中断")
+        except Exception as e:
+            print(f"[{self.name}] エラー: {e}")
+            self.log_result("error", [], str(e))
+            raise
+        finally:
+            self.close_browser()

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -38,6 +38,7 @@ class BaseCollector:
         self.headless: bool = headless if headless is not None else _is_headless()
         self.debug: bool = debug if debug is not None else _is_debug()
         self._debug_seq: int = 0  # HTML採取連番
+        self._final_status: str | None = None  # 最終 log_result の status を保持（exit code 判定用）
         if year is not None:
             self.config["target_year"] = year
             self.config["output_dir"] = f"data/income/securities/{self.code}/{year}/raw/"
@@ -193,6 +194,7 @@ class BaseCollector:
         with open(log_path, "w", encoding="utf-8") as f:
             json.dump(history, f, ensure_ascii=False, indent=2)
 
+        self._final_status = status
         print(f"[{self.name}] {status}: {message or ', '.join(files)}")
 
     def _save_session_state(self, page) -> None:
@@ -277,7 +279,11 @@ class BaseCollector:
     def _collect_core(self, page) -> None:
         raise NotImplementedError("_collect_core() をサブクラスで実装してください")
 
-    def run(self) -> None:
+    def run(self) -> int:
+        """ブラウザ起動 → _collect_core 実行 → 結果から exit code 返す。
+        success/skip → 0、error/interrupted → 1（run.py 一括ランナーで判定）。
+        skip は「対象書類なし」等の正常系（取引なし等）として 0 扱い。
+        """
         page = self.launch_browser()
         try:
             self._collect_core(page)
@@ -287,6 +293,8 @@ class BaseCollector:
         except Exception as e:
             print(f"[{self.name}] エラー: {e}")
             self.log_result("error", [], str(e))
+            self.close_browser()
             raise
         finally:
             self.close_browser()
+        return 0 if self._final_status in ("success", "skip") else 1

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -24,13 +24,19 @@ def _is_debug() -> bool:
 
 
 class BaseCollector:
-    def __init__(self, site_json_path: str | Path, year: int | None = None):
+    def __init__(
+        self,
+        site_json_path: str | Path,
+        year: int | None = None,
+        headless: bool | None = None,
+        debug: bool | None = None,
+    ):
         self.config = _load_site_config(site_json_path)
         self.code: str = self.config["code"]
         self.name: str = self.config["name"]
         self.output_dir = Path(self.config["output_dir"])
-        self.headless: bool = _is_headless()
-        self.debug: bool = _is_debug()
+        self.headless: bool = headless if headless is not None else _is_headless()
+        self.debug: bool = debug if debug is not None else _is_debug()
         self._debug_seq: int = 0  # HTML採取連番
         if year is not None:
             self.config["target_year"] = year

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -189,5 +189,31 @@ class BaseCollector:
             return False
         return True
 
+    def _write_report_json(self, data: dict) -> None:
+        """年間取引報告書 JSON を output_dir.parent/nenkantorihikihokokusho.json に保存する。"""
+        json_path = self.output_dir.parent / "nenkantorihikihokokusho.json"
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        print(f"[{self.name}] JSON 保存: {json_path}")
+
+    def _convert_xml_to_json(self, downloaded_files: list[str]) -> None:
+        """XML ファイルを TEG204 形式として JSON に変換して保存する（XML配布サイト用）。"""
+        from money_ops.converter.xml_to_json import convert_teg204_xml
+
+        year = self.config["target_year"]
+        xml_files = [f for f in downloaded_files if f.endswith(".xml")]
+        if not xml_files:
+            print(f"[{self.name}] XML が見つからないため JSON 変換をスキップします")
+            return
+        raw_files = [str(Path(f).name) for f in downloaded_files]
+        data = convert_teg204_xml(
+            xml_path=xml_files[0],
+            company=self.name,
+            code=self.code,
+            year=year,
+            raw_files=raw_files,
+        )
+        self._write_report_json(data)
+
     def collect(self) -> None:
         raise NotImplementedError("collect() をサブクラスで実装してください")

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -1,11 +1,7 @@
 import json
 import os
-import sys
-import time
 from datetime import datetime
 from pathlib import Path
-
-_SIGNAL_DIR = Path(".")  # プロジェクトルートから実行前提
 
 try:
     from dotenv import load_dotenv as _load_dotenv
@@ -53,24 +49,8 @@ class BaseCollector:
         return d
 
     def prompt(self, message: str) -> str:
-        """ユーザーへの入力要求。
-        TTY接続時: input()で待機（ターミナル直接実行）
-        非TTY時: .waiting_<code> / .signal_<code> ファイル経由で待機（Bashツール経由）
-        """
-        if sys.stdin.isatty():
-            return input(message)
-        waiting = _SIGNAL_DIR / f".waiting_{self.code}"
-        signal = _SIGNAL_DIR / f".signal_{self.code}"
-        signal.unlink(missing_ok=True)
-        waiting.write_text(message, encoding="utf-8")
-        print(f"[{self.name}] 待機中（signal: {signal}）", flush=True)
-        try:
-            while not signal.exists():
-                time.sleep(0.5)
-        finally:
-            waiting.unlink(missing_ok=True)
-        signal.unlink(missing_ok=True)
-        return ""
+        """ユーザーへの入力要求。将来的に並列収集用 EnvPrompt で差し替え可能。"""
+        return input(message)
 
     def dlog(self, message: str) -> None:
         """DEBUG=true のときだけ出力する詳細ログ"""

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -156,7 +156,11 @@ class BaseCollector:
         cookies = state.get("cookies", [])
         if not cookies:
             return
-        self._context.add_cookies(cookies)
+        # Playwright add_cookies requires url OR (domain AND path)
+        valid = [c for c in cookies if c.get("url") or (c.get("domain") and c.get("path") is not None)]
+        if not valid:
+            return
+        self._context.add_cookies(valid)
         print(f"[{self.name}] cookie {len(cookies)}件を復元しました")
 
     def close_browser(self) -> None:
@@ -229,6 +233,27 @@ class BaseCollector:
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         print(f"[{self.name}] JSON 保存: {json_path}")
+
+    def _queue_pdf_to_json(self, pdf_path: str | Path, raw_files: list[str]) -> None:
+        """PDF→JSON変換をキューファイルに登録する（収集フェーズと変換フェーズを分離）。
+        実際の変換は別途 `python skills/tax-collect/convert.py` で直列実行する。
+        """
+        year = self.config["target_year"]
+        queue_dir = Path("output") / "converting"
+        queue_dir.mkdir(parents=True, exist_ok=True)
+        queue_path = queue_dir / f"{self.code}_{year}.queue"
+        payload = {
+            "code": self.code,
+            "year": year,
+            "company": self.name,
+            "pdf_path": str(pdf_path),
+            "raw_files": list(raw_files),
+            "queued_at": datetime.now().isoformat(),
+        }
+        queue_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(f"[{self.name}] PDF→JSON変換キューに登録: {queue_path.name}")
 
     def _convert_xml_to_json(self, downloaded_files: list[str]) -> None:
         """XML ファイルを TEG204 形式として JSON に変換して保存する（XML配布サイト用）。"""

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -153,5 +153,21 @@ class BaseCollector:
 
         print(f"[{self.name}] {status}: {message or ', '.join(files)}")
 
+    def verify_pdf(self, pdf_path: str | Path) -> bool:
+        """PDF ファイルの存在・非空・マジックバイト（%PDF）を検証する。"""
+        path = Path(pdf_path)
+        if not path.exists():
+            print(f"[{self.name}] PDF が存在しません: {path}")
+            return False
+        if path.stat().st_size == 0:
+            print(f"[{self.name}] PDF が空ファイルです: {path}")
+            return False
+        with open(path, "rb") as f:
+            header = f.read(4)
+        if header != b"%PDF":
+            print(f"[{self.name}] PDF マジックバイト不正: {header!r} ({path})")
+            return False
+        return True
+
     def collect(self) -> None:
         raise NotImplementedError("collect() をサブクラスで実装してください")

--- a/src/money_ops/collector/eshishobako.py
+++ b/src/money_ops/collector/eshishobako.py
@@ -6,6 +6,7 @@ SBI・GMOクリック・野村・ひふみ投信で共通利用。
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from money_ops.utils import extract_filename, wait as _wait
@@ -14,20 +15,31 @@ _DPAW_URL_PATTERN = "**/DPAW010501020"
 
 
 def capture_dpaw_pdf(
-    popup, output_dir: Path, fallback_name: str, *, label: str = "eshishobako"
+    popup,
+    output_dir: Path,
+    fallback_name: str,
+    *,
+    label: str = "eshishobako",
+    button_name_pattern: re.Pattern[str] | str | None = None,
 ) -> str | None:
-    """「PDFファイル」ボタンをクリックし DPAW010501020 レスポンスを捕捉して保存する。
+    """指定ボタンをクリックし DPAW010501020 レスポンスを捕捉して保存する。
 
     Args:
         popup: e-shishobako SPA の Playwright Page オブジェクト
         output_dir: 保存先ディレクトリ（既に存在すること）
         fallback_name: Content-Disposition が取得できない場合のファイル名
         label: ログ出力用プレフィックス（呼び出し元の self.name を渡す）
+        button_name_pattern: クリック対象ボタンの role-name パターン。
+            None の場合は has_text="PDFファイル" でフィルタ（SBI/GMO/野村互換）。
+            同画面に複数 PDF ボタンが並ぶサイト（hifumi 等）は厳密パターン指定必須。
 
     Returns:
         保存したファイルパス（str）。失敗時は None。
     """
-    pdf_btn = popup.locator("button, a").filter(has_text="PDFファイル")
+    if button_name_pattern is not None:
+        pdf_btn = popup.get_by_role("button", name=button_name_pattern)
+    else:
+        pdf_btn = popup.locator("button, a").filter(has_text="PDFファイル")
     if pdf_btn.count() == 0:
         print(f"[{label}] PDF ボタンが見つかりません")
         return None
@@ -45,6 +57,7 @@ def capture_dpaw_pdf(
 
     popup.context.route(_DPAW_URL_PATTERN, _capture)
     try:
+        pdf_btn.first.scroll_into_view_if_needed()
         with popup.expect_popup() as pdf_popup_info:
             pdf_btn.first.click()
         pdf_popup = pdf_popup_info.value

--- a/src/money_ops/collector/eshishobako.py
+++ b/src/money_ops/collector/eshishobako.py
@@ -1,0 +1,65 @@
+"""e-shishobako（電子私書箱）共通PDF取得ヘルパー
+
+DPAW010501020 エンドポイントから PDF を route-capture する。
+SBI・GMOクリック・野村・ひふみ投信で共通利用。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from money_ops.utils import extract_filename, wait as _wait
+
+_DPAW_URL_PATTERN = "**/DPAW010501020"
+
+
+def capture_dpaw_pdf(
+    popup, output_dir: Path, fallback_name: str, *, label: str = "eshishobako"
+) -> str | None:
+    """「PDFファイル」ボタンをクリックし DPAW010501020 レスポンスを捕捉して保存する。
+
+    Args:
+        popup: e-shishobako SPA の Playwright Page オブジェクト
+        output_dir: 保存先ディレクトリ（既に存在すること）
+        fallback_name: Content-Disposition が取得できない場合のファイル名
+        label: ログ出力用プレフィックス（呼び出し元の self.name を渡す）
+
+    Returns:
+        保存したファイルパス（str）。失敗時は None。
+    """
+    pdf_btn = popup.locator("button, a").filter(has_text="PDFファイル")
+    if pdf_btn.count() == 0:
+        print(f"[{label}] PDF ボタンが見つかりません")
+        return None
+
+    pdf_bytes_holder: list[tuple[str, bytes]] = []
+
+    def _capture(route, _request) -> None:
+        response = route.fetch()
+        body = response.body()
+        if body[:4] == b"%PDF":
+            cd = response.headers.get("content-disposition", "")
+            filename = extract_filename(cd, fallback_name)
+            pdf_bytes_holder.append((filename, body))
+        route.fulfill(response=response)
+
+    popup.context.route(_DPAW_URL_PATTERN, _capture)
+    try:
+        with popup.expect_popup() as pdf_popup_info:
+            pdf_btn.first.click()
+        pdf_popup = pdf_popup_info.value
+        pdf_popup.wait_for_load_state("domcontentloaded")
+        _wait()
+        pdf_popup.close()
+    finally:
+        popup.context.unroute(_DPAW_URL_PATTERN, _capture)
+
+    if not pdf_bytes_holder:
+        print(f"[{label}] PDF レスポンスを捕捉できませんでした")
+        return None
+
+    filename, pdf_bytes = pdf_bytes_holder[0]
+    pdf_path = output_dir / filename
+    pdf_path.write_bytes(pdf_bytes)
+    print(f"[{label}] PDF 保存: {pdf_path}")
+    return str(pdf_path)

--- a/src/money_ops/converter/pdf_to_json.py
+++ b/src/money_ops/converter/pdf_to_json.py
@@ -329,7 +329,30 @@ def convert_pdf_to_json(
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     gemini_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
 
-    if anthropic_key:
+    if client is not None:
+        pdf_b64 = _encode_pdf(pdf_path)
+        message = client.messages.create(
+            model=_ANTHROPIC_MODEL,
+            max_tokens=2048,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": pdf_b64,
+                            },
+                        },
+                        {"type": "text", "text": _EXTRACTION_PROMPT},
+                    ],
+                }
+            ],
+        )
+        raw_text = message.content[0].text
+    elif anthropic_key:
         raw_text = _extract_with_anthropic(pdf_path, anthropic_key)
     else:
         try:

--- a/src/money_ops/utils.py
+++ b/src/money_ops/utils.py
@@ -1,0 +1,7 @@
+import random
+import time
+
+
+def wait(lo: float = 1.0, hi: float = 3.0) -> None:
+    """lo〜hi 秒のランダム待機（レート制限・BAN 対策）"""
+    time.sleep(random.uniform(lo, hi))

--- a/src/money_ops/utils.py
+++ b/src/money_ops/utils.py
@@ -1,7 +1,16 @@
 import random
+import re
 import time
+
+_RE_FILENAME = re.compile(r'filename[^;=\n]*=([^;\n]*)')
 
 
 def wait(lo: float = 1.0, hi: float = 3.0) -> None:
     """lo〜hi 秒のランダム待機（レート制限・BAN 対策）"""
     time.sleep(random.uniform(lo, hi))
+
+
+def extract_filename(content_disposition: str, fallback: str = "") -> str:
+    """Content-Disposition ヘッダからファイル名を抽出する。取得できなければ fallback を返す。"""
+    m = _RE_FILENAME.search(content_disposition)
+    return m.group(1).strip().strip('"\'') if m else fallback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""共通テストヘルパー"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SITES_DIR = PROJECT_ROOT / "skills" / "tax-collect" / "sites"
+FIXTURE_XML = PROJECT_ROOT / "tests" / "fixtures" / "teg204_sample.xml"
+
+
+def load_site_module(site_code: str):
+    """site_code の collect.py を importlib でロードして返す"""
+    collect_py = SITES_DIR / site_code / "collect.py"
+    mod_name = site_code.replace("-", "_") + "_collect"
+    spec = importlib.util.spec_from_file_location(mod_name, collect_py)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def build_collector(tmp_path: Path, site_code: str, collector_cls, year: int = 2025):
+    """tmp_path に一時 site.json を作り collector インスタンスを返す"""
+    orig = SITES_DIR / site_code / "site.json"
+    config = json.loads(orig.read_text(encoding="utf-8"))
+    config["output_dir"] = str(tmp_path / "raw")
+    config["target_year"] = year
+    tmp_site = tmp_path / "site.json"
+    tmp_site.write_text(json.dumps(config, ensure_ascii=False), encoding="utf-8")
+    return collector_cls(site_json_path=tmp_site)

--- a/tests/test_base_collector.py
+++ b/tests/test_base_collector.py
@@ -1,6 +1,9 @@
 import json
 import os
+import threading
+import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -45,3 +48,33 @@ def test_collect_core_not_implemented():
     collector = BaseCollector(SITE_JSON)
     with pytest.raises(NotImplementedError):
         collector._collect_core(None)
+
+
+def test_prompt_tty_uses_input():
+    collector = BaseCollector(SITE_JSON)
+    with patch("sys.stdin") as mock_stdin, patch("builtins.input", return_value="ok") as mock_input:
+        mock_stdin.isatty.return_value = True
+        result = collector.prompt("test: ")
+    mock_input.assert_called_once_with("test: ")
+    assert result == "ok"
+
+
+def test_prompt_non_tty_uses_signal_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    collector = BaseCollector(SITE_JSON)
+
+    def _create_signal():
+        time.sleep(0.3)
+        (tmp_path / f".signal_{collector.code}").write_text("", encoding="utf-8")
+
+    t = threading.Thread(target=_create_signal)
+    t.start()
+
+    with patch("sys.stdin") as mock_stdin:
+        mock_stdin.isatty.return_value = False
+        result = collector.prompt("ログイン完了後Enter: ")
+
+    t.join()
+    assert result == ""
+    assert not (tmp_path / f".waiting_{collector.code}").exists()
+    assert not (tmp_path / f".signal_{collector.code}").exists()

--- a/tests/test_base_collector.py
+++ b/tests/test_base_collector.py
@@ -41,7 +41,7 @@ def test_prepare_directory(tmp_path, monkeypatch):
     assert collector.output_dir.exists()
 
 
-def test_collect_not_implemented():
+def test_collect_core_not_implemented():
     collector = BaseCollector(SITE_JSON)
     with pytest.raises(NotImplementedError):
-        collector.collect()
+        collector._collect_core(None)

--- a/tests/test_base_collector.py
+++ b/tests/test_base_collector.py
@@ -1,9 +1,6 @@
 import json
 import os
-import threading
-import time
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -48,33 +45,3 @@ def test_collect_core_not_implemented():
     collector = BaseCollector(SITE_JSON)
     with pytest.raises(NotImplementedError):
         collector._collect_core(None)
-
-
-def test_prompt_tty_uses_input():
-    collector = BaseCollector(SITE_JSON)
-    with patch("sys.stdin") as mock_stdin, patch("builtins.input", return_value="ok") as mock_input:
-        mock_stdin.isatty.return_value = True
-        result = collector.prompt("test: ")
-    mock_input.assert_called_once_with("test: ")
-    assert result == "ok"
-
-
-def test_prompt_non_tty_uses_signal_file(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    collector = BaseCollector(SITE_JSON)
-
-    def _create_signal():
-        time.sleep(0.3)
-        (tmp_path / f".signal_{collector.code}").write_text("", encoding="utf-8")
-
-    t = threading.Thread(target=_create_signal)
-    t.start()
-
-    with patch("sys.stdin") as mock_stdin:
-        mock_stdin.isatty.return_value = False
-        result = collector.prompt("ログイン完了後Enter: ")
-
-    t.join()
-    assert result == ""
-    assert not (tmp_path / f".waiting_{collector.code}").exists()
-    assert not (tmp_path / f".signal_{collector.code}").exists()

--- a/tests/test_collectors_all.py
+++ b/tests/test_collectors_all.py
@@ -79,16 +79,18 @@ def test_output_dir_contains_year(tmp_path, code, cls_name):
 
 
 @pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
-def test_collect_not_implemented_on_base(tmp_path, code, cls_name):
-    """collect() は各社で実装されている（NotImplementedError を投げないこと）"""
+def test_collect_core_implemented(tmp_path, code, cls_name):
+    """_collect_core() は各社で実装されている（BaseCollector の NotImplementedError を上書きしていること）"""
     mod = load_site_module(code)
     cls = getattr(mod, cls_name)
     collector = build_collector(tmp_path, code, cls)
-    # collect メソッドが存在し、BaseCollector の NotImplementedError を上書きしていること
-    assert callable(getattr(collector, "collect", None))
-    # クラス自身のメソッド（継承元の NotImplementedError ではない）
-    assert "collect" in cls.__dict__ or any(
-        "collect" in C.__dict__ for C in cls.__mro__[1:-1]
+    # webull は collect() のみ実装（Android 自動化）
+    if code == "webull":
+        assert callable(getattr(collector, "collect", None))
+        return
+    assert callable(getattr(collector, "_collect_core", None))
+    assert "_collect_core" in cls.__dict__ or any(
+        "_collect_core" in C.__dict__ for C in cls.__mro__[1:-1]
     )
 
 

--- a/tests/test_collectors_all.py
+++ b/tests/test_collectors_all.py
@@ -94,9 +94,7 @@ def test_collect_not_implemented_on_base(tmp_path, code, cls_name):
 
 @pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
 def test_verify_pdf_has_method(tmp_path, code, cls_name):
-    """verify_pdf() が BaseCollector から継承されていること（webull は BaseCollector 未継承のため除外）"""
-    if code == "webull":
-        pytest.skip("webull は BaseCollector 未継承（M-4 で対応予定）")
+    """verify_pdf() が BaseCollector から継承されていること"""
     mod = load_site_module(code)
     cls = getattr(mod, cls_name)
     collector = build_collector(tmp_path, code, cls)

--- a/tests/test_collectors_all.py
+++ b/tests/test_collectors_all.py
@@ -90,3 +90,46 @@ def test_collect_not_implemented_on_base(tmp_path, code, cls_name):
     assert "collect" in cls.__dict__ or any(
         "collect" in C.__dict__ for C in cls.__mro__[1:-1]
     )
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_verify_pdf_has_method(tmp_path, code, cls_name):
+    """verify_pdf() が BaseCollector から継承されていること（webull は BaseCollector 未継承のため除外）"""
+    if code == "webull":
+        pytest.skip("webull は BaseCollector 未継承（M-4 で対応予定）")
+    mod = load_site_module(code)
+    cls = getattr(mod, cls_name)
+    collector = build_collector(tmp_path, code, cls)
+    assert callable(getattr(collector, "verify_pdf", None))
+
+
+def test_verify_pdf_valid(tmp_path):
+    """正常な PDF（%PDF ヘッダ）は True を返す"""
+    from tests.conftest import build_collector, load_site_module
+    mod = load_site_module("sbi")
+    c = build_collector(tmp_path, "sbi", mod.SBICollector)
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake content")
+    assert c.verify_pdf(pdf) is True
+
+
+def test_verify_pdf_not_exists(tmp_path):
+    mod = load_site_module("sbi")
+    c = build_collector(tmp_path, "sbi", mod.SBICollector)
+    assert c.verify_pdf(tmp_path / "missing.pdf") is False
+
+
+def test_verify_pdf_empty(tmp_path):
+    mod = load_site_module("sbi")
+    c = build_collector(tmp_path, "sbi", mod.SBICollector)
+    pdf = tmp_path / "empty.pdf"
+    pdf.write_bytes(b"")
+    assert c.verify_pdf(pdf) is False
+
+
+def test_verify_pdf_wrong_magic(tmp_path):
+    mod = load_site_module("sbi")
+    c = build_collector(tmp_path, "sbi", mod.SBICollector)
+    pdf = tmp_path / "notpdf.pdf"
+    pdf.write_bytes(b"HTML<html>not a pdf")
+    assert c.verify_pdf(pdf) is False

--- a/tests/test_collectors_all.py
+++ b/tests/test_collectors_all.py
@@ -1,0 +1,92 @@
+"""全社 collect.py の共通構造テスト（パラメータ化）"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import SITES_DIR, build_collector, load_site_module
+
+# (site_code, collector_class_name)
+ALL_SITES = [
+    ("sbi",              "SBICollector"),
+    ("rakuten",          "RakutenCollector"),
+    ("nomura",           "NomuraCollector"),
+    ("monex",            "MonexCollector"),
+    ("matsui",           "MatsuiCollector"),
+    ("gmo-click",        "GMOClickCollector"),
+    ("smbcnikko",        "SMBCNikkoCollector"),
+    ("mufg-esmart",      "MufgEsmartCollector"),
+    ("tsumiki",          "TsumikiCollector"),
+    ("daiwa-connect",    "DaiwaConnectCollector"),
+    ("paypay",           "PaypayCollector"),
+    ("hifumi",           "HifumiCollector"),
+    ("sawakami",         "SawakamiCollector"),
+    ("nomura-mochikabu", "NomuraMochikabuCollector"),
+    ("webull",           "WebullCollector"),
+]
+
+IDS = [code for code, _ in ALL_SITES]
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_collect_py_exists(code, cls_name):
+    assert (SITES_DIR / code / "collect.py").exists()
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_site_json_exists(code, cls_name):
+    assert (SITES_DIR / code / "site.json").exists()
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_site_json_required_fields(code, cls_name):
+    data = json.loads((SITES_DIR / code / "site.json").read_text(encoding="utf-8"))
+    for field in ("code", "name", "output_dir", "target_year"):
+        assert field in data, f"{code}/site.json に {field} がない"
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_module_importable(code, cls_name):
+    mod = load_site_module(code)
+    assert hasattr(mod, cls_name), f"{code}: {cls_name} クラスが存在しない"
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_instantiation(tmp_path, code, cls_name):
+    mod = load_site_module(code)
+    cls = getattr(mod, cls_name)
+    collector = build_collector(tmp_path, code, cls)
+    assert collector.code == code
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_year_param(tmp_path, code, cls_name):
+    mod = load_site_module(code)
+    cls = getattr(mod, cls_name)
+    collector = build_collector(tmp_path, code, cls, year=2024)
+    assert collector.config["target_year"] == 2024
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_output_dir_contains_year(tmp_path, code, cls_name):
+    mod = load_site_module(code)
+    cls = getattr(mod, cls_name)
+    collector = build_collector(tmp_path, code, cls, year=2025)
+    assert str(collector.output_dir) != ""
+
+
+@pytest.mark.parametrize("code,cls_name", ALL_SITES, ids=IDS)
+def test_collect_not_implemented_on_base(tmp_path, code, cls_name):
+    """collect() は各社で実装されている（NotImplementedError を投げないこと）"""
+    mod = load_site_module(code)
+    cls = getattr(mod, cls_name)
+    collector = build_collector(tmp_path, code, cls)
+    # collect メソッドが存在し、BaseCollector の NotImplementedError を上書きしていること
+    assert callable(getattr(collector, "collect", None))
+    # クラス自身のメソッド（継承元の NotImplementedError ではない）
+    assert "collect" in cls.__dict__ or any(
+        "collect" in C.__dict__ for C in cls.__mro__[1:-1]
+    )

--- a/tests/test_daiwaconnect_collector.py
+++ b/tests/test_daiwaconnect_collector.py
@@ -32,7 +32,7 @@ def test_login_first_goto_is_login_url(tmp_path):
         result = c._login(page)
 
     # 最初の goto が LOGIN_URL であること
-    assert page.goto.call_args_list[0] == call(_mod._LOGIN_URL)
+    assert page.goto.call_args_list[0] == call(c.config["login_url"])
     assert result is page
 
 

--- a/tests/test_daiwaconnect_collector.py
+++ b/tests/test_daiwaconnect_collector.py
@@ -49,7 +49,7 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "_navigate_to_annual_report"), \
          patch.object(c, "_download_pdf_via_route", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "error"
@@ -70,7 +70,7 @@ def test_collect_success_flow(tmp_path):
          patch.object(c, "_download_pdf_via_route", return_value=pdf_path), \
          patch.object(_mod, "convert_pdf_to_json", return_value={"code": _CODE}), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "success"

--- a/tests/test_daiwaconnect_collector.py
+++ b/tests/test_daiwaconnect_collector.py
@@ -1,0 +1,76 @@
+"""大和CONNECT証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "daiwa-connect"
+_mod = load_site_module(_CODE)
+DaiwaConnectCollector = _mod.DaiwaConnectCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, DaiwaConnectCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "大和コネクト証券"
+
+
+def test_login_first_goto_is_login_url(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    # セッション有効 → webbroker3 へリダイレクト済みを想定
+    page.url = "https://www.connect-sec.co.jp/webbroker3/top"
+
+    with patch.object(_mod, "_wait"):
+        result = c._login(page)
+
+    # 最初の goto が LOGIN_URL であること
+    assert page.goto.call_args_list[0] == call(_mod._LOGIN_URL)
+    assert result is page
+
+
+def test_collect_error_when_pdf_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+    page2 = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_login", return_value=page1), \
+         patch.object(c, "_open_electronic_delivery", return_value=page2), \
+         patch.object(c, "_navigate_to_annual_report"), \
+         patch.object(c, "_download_pdf_via_route", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "error"
+
+
+def test_collect_success_flow(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+    page2 = MagicMock()
+    pdf_path = str(tmp_path / "raw" / "report.pdf")
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_login", return_value=page1), \
+         patch.object(c, "_open_electronic_delivery", return_value=page2), \
+         patch.object(c, "_navigate_to_annual_report"), \
+         patch.object(c, "_download_pdf_via_route", return_value=pdf_path), \
+         patch.object(_mod, "convert_pdf_to_json", return_value={"code": _CODE}), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "success"

--- a/tests/test_gmoclick_collector.py
+++ b/tests/test_gmoclick_collector.py
@@ -67,7 +67,7 @@ def test_find_report_row_button_not_found(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     c = _make(tmp_path)
-    c._convert_to_json(["data/foo.pdf"])
+    c._convert_xml_to_json(["data/foo.pdf"])
     assert "スキップ" in capsys.readouterr().out
 
 
@@ -76,7 +76,7 @@ def test_convert_to_json_with_xml(tmp_path):
         pytest.skip("teg204_sample.xml が存在しない")
     c = _make(tmp_path)
     c.output_dir.mkdir(parents=True, exist_ok=True)
-    c._convert_to_json([str(FIXTURE_XML)])
+    c._convert_xml_to_json([str(FIXTURE_XML)])
     json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))

--- a/tests/test_gmoclick_collector.py
+++ b/tests/test_gmoclick_collector.py
@@ -34,7 +34,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_wait_for_login_skips_when_logged_in(tmp_path):

--- a/tests/test_gmoclick_collector.py
+++ b/tests/test_gmoclick_collector.py
@@ -32,7 +32,7 @@ def test_year_month_patterns():
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 
@@ -41,9 +41,9 @@ def test_wait_for_login_skips_when_logged_in(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
     page.url = "https://kabu.click-sec.com/sec2/mypage/top.do"
-    with patch("builtins.input") as mock_input:
+    with patch.object(c, "prompt") as mock_prompt:
         c._wait_for_login(page)
-    mock_input.assert_not_called()
+    mock_prompt.assert_not_called()
     assert c._session is page
 
 

--- a/tests/test_gmoclick_collector.py
+++ b/tests/test_gmoclick_collector.py
@@ -95,7 +95,7 @@ def test_collect_skip_when_download_empty(tmp_path):
          patch.object(c, "_download_files", return_value=[]), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_gmoclick_collector.py
+++ b/tests/test_gmoclick_collector.py
@@ -1,0 +1,91 @@
+"""GMOクリック証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import FIXTURE_XML, build_collector, load_site_module
+
+_CODE = "gmo-click"
+_mod = load_site_module(_CODE)
+GMOClickCollector = _mod.GMOClickCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, GMOClickCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "GMOクリック証券"
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025/12" in patterns
+    assert "2026/01" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_find_report_row_button_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    popup = MagicMock()
+    btn = MagicMock()
+    btn.count.return_value = 1
+    popup.get_by_role.return_value.filter.return_value = btn
+    result = c._find_report_row_button(popup, 2025)
+    assert result is btn.first
+
+
+def test_find_report_row_button_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    popup = MagicMock()
+    popup.get_by_role.return_value.filter.return_value.count.return_value = 0
+    result = c._find_report_row_button(popup, 2025)
+    assert result is None
+
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    c = _make(tmp_path)
+    c._convert_to_json(["data/foo.pdf"])
+    assert "スキップ" in capsys.readouterr().out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    if not FIXTURE_XML.exists():
+        pytest.skip("teg204_sample.xml が存在しない")
+    c = _make(tmp_path)
+    c.output_dir.mkdir(parents=True, exist_ok=True)
+    c._convert_to_json([str(FIXTURE_XML)])
+    json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == _CODE
+
+
+def test_collect_skip_when_download_empty(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    popup = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_report_popup", return_value=popup), \
+         patch.object(c, "_download_files", return_value=[]), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_gmoclick_collector.py
+++ b/tests/test_gmoclick_collector.py
@@ -37,6 +37,16 @@ def test_wait_for_login(tmp_path):
     page.goto.assert_called_once_with(_mod._LOGIN_URL)
 
 
+def test_wait_for_login_skips_when_logged_in(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    page.url = "https://kabu.click-sec.com/sec2/mypage/top.do"
+    with patch("builtins.input") as mock_input:
+        c._wait_for_login(page)
+    mock_input.assert_not_called()
+    assert c._session is page
+
+
 def test_find_report_row_button_found(tmp_path):
     c = _make(tmp_path, year=2025)
     popup = MagicMock()

--- a/tests/test_hifumi_collector.py
+++ b/tests/test_hifumi_collector.py
@@ -41,7 +41,7 @@ def test_wait_for_login_returns_page2(tmp_path):
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         result = c._wait_for_login(page)
 
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
     assert result is page2
 
 

--- a/tests/test_hifumi_collector.py
+++ b/tests/test_hifumi_collector.py
@@ -84,7 +84,8 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "_navigate_to_eshishobako", return_value=page2), \
          patch.object(c, "_find_date_button", return_value=date_btn), \
          patch.object(c, "_open_report_detail", return_value=True), \
-         patch.object(c, "_download_pdf_via_route", return_value=None), \
+         patch.object(c, "prepare_directory"), \
+         patch.object(_mod, "capture_dpaw_pdf", return_value=None), \
          patch.object(c, "log_result") as mock_log:
         c.collect()
 

--- a/tests/test_hifumi_collector.py
+++ b/tests/test_hifumi_collector.py
@@ -65,7 +65,7 @@ def test_collect_skip_when_date_button_not_found(tmp_path):
          patch.object(c, "_navigate_to_eshishobako", return_value=page2), \
          patch.object(c, "_find_date_button", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"
@@ -87,7 +87,7 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "prepare_directory"), \
          patch.object(_mod, "capture_dpaw_pdf", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "error"

--- a/tests/test_hifumi_collector.py
+++ b/tests/test_hifumi_collector.py
@@ -1,0 +1,92 @@
+"""ひふみ投信 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "hifumi"
+_mod = load_site_module(_CODE)
+HifumiCollector = _mod.HifumiCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, HifumiCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "ひふみ投信"
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025/12" in patterns
+    assert "2026/01" in patterns
+
+
+def test_wait_for_login_returns_page2(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    page.get_by_role.return_value.count.return_value = 0
+    page2 = MagicMock()
+    popup_cm = MagicMock()
+    popup_cm.__enter__ = MagicMock(return_value=MagicMock(value=page2))
+    popup_cm.__exit__ = MagicMock(return_value=False)
+    page.expect_popup.return_value = popup_cm
+
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        result = c._wait_for_login(page)
+
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    assert result is page2
+
+
+def test_find_date_button_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page2 = MagicMock()
+    page2.get_by_role.return_value.filter.return_value.count.return_value = 0
+    result = c._find_date_button(page2, 2025)
+    assert result is None
+
+
+def test_collect_skip_when_date_button_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+    page2 = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login", return_value=page1), \
+         patch.object(c, "_navigate_to_eshishobako", return_value=page2), \
+         patch.object(c, "_find_date_button", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"
+
+
+def test_collect_error_when_pdf_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+    page2 = MagicMock()
+    date_btn = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login", return_value=page1), \
+         patch.object(c, "_navigate_to_eshishobako", return_value=page2), \
+         patch.object(c, "_find_date_button", return_value=date_btn), \
+         patch.object(c, "_open_report_detail", return_value=True), \
+         patch.object(c, "_download_pdf_via_route", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "error"

--- a/tests/test_hifumi_collector.py
+++ b/tests/test_hifumi_collector.py
@@ -38,7 +38,7 @@ def test_wait_for_login_returns_page2(tmp_path):
     popup_cm.__exit__ = MagicMock(return_value=False)
     page.expect_popup.return_value = popup_cm
 
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         result = c._wait_for_login(page)
 
     page.goto.assert_called_once_with(c.config["login_url"])

--- a/tests/test_matsui_collector.py
+++ b/tests/test_matsui_collector.py
@@ -34,7 +34,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_find_xml_link_found(tmp_path):

--- a/tests/test_matsui_collector.py
+++ b/tests/test_matsui_collector.py
@@ -57,7 +57,7 @@ def test_find_xml_link_not_found(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     c = _make(tmp_path)
-    c._convert_to_json(["data/foo.pdf"])
+    c._convert_xml_to_json(["data/foo.pdf"])
     assert "スキップ" in capsys.readouterr().out
 
 
@@ -66,7 +66,7 @@ def test_convert_to_json_with_xml(tmp_path):
         pytest.skip("teg204_sample.xml が存在しない")
     c = _make(tmp_path)
     c.output_dir.mkdir(parents=True, exist_ok=True)
-    c._convert_to_json([str(FIXTURE_XML)])
+    c._convert_xml_to_json([str(FIXTURE_XML)])
     json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))

--- a/tests/test_matsui_collector.py
+++ b/tests/test_matsui_collector.py
@@ -32,7 +32,7 @@ def test_year_month_patterns():
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 

--- a/tests/test_matsui_collector.py
+++ b/tests/test_matsui_collector.py
@@ -85,7 +85,7 @@ def test_collect_skip_when_download_empty(tmp_path):
          patch.object(c, "_download_files", return_value=[]), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_matsui_collector.py
+++ b/tests/test_matsui_collector.py
@@ -1,0 +1,91 @@
+"""松井証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import FIXTURE_XML, build_collector, load_site_module
+
+_CODE = "matsui"
+_mod = load_site_module(_CODE)
+MatsuiCollector = _mod.MatsuiCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, MatsuiCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "松井証券"
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025年12月" in patterns
+    assert "2026年01月" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_find_xml_link_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    frame = MagicMock()
+    link = MagicMock()
+    link.count.return_value = 1
+    frame.get_by_role.return_value = link
+    result = c._find_xml_link(frame, 2025)
+    assert result is link.first
+
+
+def test_find_xml_link_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    frame = MagicMock()
+    frame.get_by_role.return_value.count.return_value = 0
+    result = c._find_xml_link(frame, 2025)
+    assert result is None
+
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    c = _make(tmp_path)
+    c._convert_to_json(["data/foo.pdf"])
+    assert "スキップ" in capsys.readouterr().out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    if not FIXTURE_XML.exists():
+        pytest.skip("teg204_sample.xml が存在しない")
+    c = _make(tmp_path)
+    c.output_dir.mkdir(parents=True, exist_ok=True)
+    c._convert_to_json([str(FIXTURE_XML)])
+    json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == _CODE
+
+
+def test_collect_skip_when_download_empty(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    popup = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_report_popup", return_value=popup), \
+         patch.object(c, "_download_files", return_value=[]), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_monex_collector.py
+++ b/tests/test_monex_collector.py
@@ -32,7 +32,7 @@ def test_year_month_patterns():
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 
@@ -41,9 +41,9 @@ def test_wait_for_login_skips_when_logged_in(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
     page.url = "https://mst.monex.co.jp/pc/ITS/usr/TopMenu.jsp"
-    with patch("builtins.input") as mock_input:
+    with patch.object(c, "prompt") as mock_prompt:
         c._wait_for_login(page)
-    mock_input.assert_not_called()
+    mock_prompt.assert_not_called()
 
 
 def test_find_xml_link_found(tmp_path):

--- a/tests/test_monex_collector.py
+++ b/tests/test_monex_collector.py
@@ -34,7 +34,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_wait_for_login_skips_when_logged_in(tmp_path):

--- a/tests/test_monex_collector.py
+++ b/tests/test_monex_collector.py
@@ -76,7 +76,7 @@ def test_find_pdf_link_found(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     c = _make(tmp_path)
-    c._convert_to_json(["data/foo.pdf"])
+    c._convert_xml_to_json(["data/foo.pdf"])
     assert "スキップ" in capsys.readouterr().out
 
 
@@ -85,7 +85,7 @@ def test_convert_to_json_with_xml(tmp_path):
         pytest.skip("teg204_sample.xml が存在しない")
     c = _make(tmp_path)
     c.output_dir.mkdir(parents=True, exist_ok=True)
-    c._convert_to_json([str(FIXTURE_XML)])
+    c._convert_xml_to_json([str(FIXTURE_XML)])
     json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))

--- a/tests/test_monex_collector.py
+++ b/tests/test_monex_collector.py
@@ -1,0 +1,100 @@
+"""マネックス証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import FIXTURE_XML, build_collector, load_site_module
+
+_CODE = "monex"
+_mod = load_site_module(_CODE)
+MonexCollector = _mod.MonexCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, MonexCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "マネックス証券"
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025年12月" in patterns
+    assert "2026年01月" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_find_xml_link_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    link = MagicMock()
+    link.count.return_value = 1
+    page.get_by_role.return_value = link
+    result = c._find_xml_link(page, 2025)
+    assert result is link.first
+
+
+def test_find_xml_link_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page.get_by_role.return_value.count.return_value = 0
+    result = c._find_xml_link(page, 2025)
+    assert result is None
+
+
+def test_find_pdf_link_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    link = MagicMock()
+    link.count.return_value = 1
+    page.get_by_role.return_value.filter.return_value = link
+    result = c._find_pdf_link(page, 2025)
+    assert result is link.first
+
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    c = _make(tmp_path)
+    c._convert_to_json(["data/foo.pdf"])
+    assert "スキップ" in capsys.readouterr().out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    if not FIXTURE_XML.exists():
+        pytest.skip("teg204_sample.xml が存在しない")
+    c = _make(tmp_path)
+    c.output_dir.mkdir(parents=True, exist_ok=True)
+    c._convert_to_json([str(FIXTURE_XML)])
+    json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == _CODE
+
+
+def test_collect_skip_when_report_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page.get_by_role.return_value.count.return_value = 0
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_report_list"), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_monex_collector.py
+++ b/tests/test_monex_collector.py
@@ -103,7 +103,7 @@ def test_collect_skip_when_report_not_found(tmp_path):
          patch.object(c, "_navigate_to_report_list"), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_monex_collector.py
+++ b/tests/test_monex_collector.py
@@ -37,6 +37,15 @@ def test_wait_for_login(tmp_path):
     page.goto.assert_called_once_with(_mod._LOGIN_URL)
 
 
+def test_wait_for_login_skips_when_logged_in(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    page.url = "https://mst.monex.co.jp/pc/ITS/usr/TopMenu.jsp"
+    with patch("builtins.input") as mock_input:
+        c._wait_for_login(page)
+    mock_input.assert_not_called()
+
+
 def test_find_xml_link_found(tmp_path):
     c = _make(tmp_path, year=2025)
     page = MagicMock()

--- a/tests/test_mufgesmart_collector.py
+++ b/tests/test_mufgesmart_collector.py
@@ -1,0 +1,81 @@
+"""三菱UFJ eスマート証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "mufg-esmart"
+_mod = load_site_module(_CODE)
+MufgEsmartCollector = _mod.MufgEsmartCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, MufgEsmartCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "MUFG eスマート証券"
+
+
+def test_save_session_skips_empty_cookies(tmp_path):
+    c = _make(tmp_path)
+    fake_profile = tmp_path / "browser_profile"
+    page = MagicMock()
+    page.context.storage_state.return_value = {"cookies": []}
+    with patch.object(c, "_browser_profile_dir", return_value=fake_profile):
+        c._save_session(page)
+    state_path = fake_profile / "storage_state.json"
+    assert not state_path.exists()
+
+
+def test_save_session_saves_when_cookies_exist(tmp_path):
+    c = _make(tmp_path)
+    fake_profile = tmp_path / "browser_profile"
+    fake_profile.mkdir(parents=True, exist_ok=True)
+    page = MagicMock()
+    page.context.storage_state.return_value = {"cookies": [{"name": "s", "value": "v"}]}
+    with patch.object(c, "_browser_profile_dir", return_value=fake_profile):
+        c._save_session(page)
+    state_path = fake_profile / "storage_state.json"
+    assert state_path.exists()
+
+
+def test_collect_error_when_pdf_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_open_trade_page", return_value=page1), \
+         patch.object(c, "_navigate_to_pdf_report"), \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "error"
+
+
+def test_collect_success_flow(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+    pdf_path = str(tmp_path / "raw" / "report.pdf")
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_open_trade_page", return_value=page1), \
+         patch.object(c, "_navigate_to_pdf_report"), \
+         patch.object(c, "_download_pdf", return_value=pdf_path), \
+         patch.object(_mod, "convert_pdf_to_json", return_value={"code": _CODE}), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "success"

--- a/tests/test_mufgesmart_collector.py
+++ b/tests/test_mufgesmart_collector.py
@@ -56,7 +56,7 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "_navigate_to_pdf_report"), \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "error"
@@ -75,7 +75,7 @@ def test_collect_success_flow(tmp_path):
          patch.object(c, "_download_pdf", return_value=pdf_path), \
          patch.object(_mod, "convert_pdf_to_json", return_value={"code": _CODE}), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "success"

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -83,6 +83,7 @@ def test_collect_skip_when_report_not_found(tmp_path):
     with patch.object(c, "launch_browser", return_value=page), \
          patch.object(c, "close_browser"), \
          patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_save_session_state"), \
          patch.object(c, "_navigate_to_report_popup", return_value=popup), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -33,7 +33,7 @@ def test_year_month_patterns():
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 
@@ -42,9 +42,9 @@ def test_wait_for_login_skips_when_logged_in(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
     page.url = "https://hometrade.nomura.co.jp/web/top.do"
-    with patch("builtins.input") as mock_input:
+    with patch.object(c, "prompt") as mock_prompt:
         c._wait_for_login(page)
-    mock_input.assert_not_called()
+    mock_prompt.assert_not_called()
     assert c._session is page
 
 

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -38,6 +38,16 @@ def test_wait_for_login(tmp_path):
     page.goto.assert_called_once_with(_mod._LOGIN_URL)
 
 
+def test_wait_for_login_skips_when_logged_in(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    page.url = "https://hometrade.nomura.co.jp/web/top.do"
+    with patch("builtins.input") as mock_input:
+        c._wait_for_login(page)
+    mock_input.assert_not_called()
+    assert c._session is page
+
+
 def test_find_report_row_button_found(tmp_path):
     c = _make(tmp_path, year=2025)
     popup = MagicMock()

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -68,7 +68,7 @@ def test_find_report_row_button_not_found(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     c = _make(tmp_path)
-    c._convert_to_json(["data/foo.pdf"])
+    c._convert_xml_to_json(["data/foo.pdf"])
     assert "スキップ" in capsys.readouterr().out
 
 
@@ -77,7 +77,7 @@ def test_convert_to_json_with_xml(tmp_path):
         pytest.skip("teg204_sample.xml が存在しない")
     c = _make(tmp_path)
     c.output_dir.mkdir(parents=True, exist_ok=True)
-    c._convert_to_json([str(FIXTURE_XML)])
+    c._convert_xml_to_json([str(FIXTURE_XML)])
     json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -97,7 +97,7 @@ def test_collect_skip_when_report_not_found(tmp_path):
          patch.object(c, "_navigate_to_report_popup", return_value=popup), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -1,0 +1,92 @@
+"""野村證券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import FIXTURE_XML, build_collector, load_site_module
+
+_CODE = "nomura"
+_mod = load_site_module(_CODE)
+NomuraCollector = _mod.NomuraCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, NomuraCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "野村證券"
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025/12" in patterns
+    assert "2026/01" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_find_report_row_button_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    popup = MagicMock()
+    btn = MagicMock()
+    btn.count.return_value = 1
+    popup.get_by_role.return_value.filter.return_value = btn
+    result = c._find_report_row_button(popup, 2025)
+    assert result is btn.first
+
+
+def test_find_report_row_button_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    popup = MagicMock()
+    popup.get_by_role.return_value.filter.return_value.count.return_value = 0
+    result = c._find_report_row_button(popup, 2025)
+    assert result is None
+
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    c = _make(tmp_path)
+    c._convert_to_json(["data/foo.pdf"])
+    assert "スキップ" in capsys.readouterr().out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    if not FIXTURE_XML.exists():
+        pytest.skip("teg204_sample.xml が存在しない")
+    c = _make(tmp_path)
+    c.output_dir.mkdir(parents=True, exist_ok=True)
+    c._convert_to_json([str(FIXTURE_XML)])
+    json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == _CODE
+
+
+def test_collect_skip_when_report_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    popup = MagicMock()
+    popup.get_by_role.return_value.filter.return_value.count.return_value = 0
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_report_popup", return_value=popup), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_nomura_collector.py
+++ b/tests/test_nomura_collector.py
@@ -35,7 +35,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_wait_for_login_skips_when_logged_in(tmp_path):

--- a/tests/test_nomura_mochikabu_collector.py
+++ b/tests/test_nomura_mochikabu_collector.py
@@ -1,0 +1,82 @@
+"""野村證券持株会 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "nomura-mochikabu"
+_mod = load_site_module(_CODE)
+NomuraMochikabuCollector = _mod.NomuraMochikabuCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, NomuraMochikabuCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "野村證券持株会"
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025年12月" in patterns
+    assert "2026年01月" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_parse_hidden_inputs_basic(tmp_path):
+    c = _make(tmp_path)
+    html = '''
+    <form>
+      <input type="hidden" name="token" value="abc123">
+      <input type="hidden" name="year" value="2025">
+      <input type="text" name="visible" value="ignore">
+    </form>
+    '''
+    result = c._parse_hidden_inputs(html)
+    assert result["token"] == "abc123"
+    assert result["year"] == "2025"
+    assert "visible" not in result
+
+
+def test_parse_hidden_inputs_empty(tmp_path):
+    c = _make(tmp_path)
+    result = c._parse_hidden_inputs("<html><body></body></html>")
+    assert result == {}
+
+
+def test_find_report_link_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page.locator.return_value.count.return_value = 0
+    result = c._find_report_link(page, 2025)
+    assert result is None
+
+
+def test_collect_skip_when_report_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_list"), \
+         patch.object(c, "_find_report_link", return_value=None), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_nomura_mochikabu_collector.py
+++ b/tests/test_nomura_mochikabu_collector.py
@@ -76,7 +76,7 @@ def test_collect_skip_when_report_not_found(tmp_path):
          patch.object(c, "_find_report_link", return_value=None), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_nomura_mochikabu_collector.py
+++ b/tests/test_nomura_mochikabu_collector.py
@@ -33,7 +33,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_parse_hidden_inputs_basic(tmp_path):

--- a/tests/test_nomura_mochikabu_collector.py
+++ b/tests/test_nomura_mochikabu_collector.py
@@ -31,7 +31,7 @@ def test_year_month_patterns():
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 

--- a/tests/test_paypay_collector.py
+++ b/tests/test_paypay_collector.py
@@ -53,7 +53,7 @@ def test_collect_calls_login_when_not_logged_in(tmp_path):
          patch.object(c, "_navigate_to_documents"), \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result"):
-        c.collect()
+        c.run()
 
     mock_login.assert_called_once()
 
@@ -69,7 +69,7 @@ def test_collect_skips_login_when_logged_in(tmp_path):
          patch.object(c, "_navigate_to_documents"), \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result"):
-        c.collect()
+        c.run()
 
     mock_login.assert_not_called()
 
@@ -84,7 +84,7 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "_navigate_to_documents"), \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "error"

--- a/tests/test_paypay_collector.py
+++ b/tests/test_paypay_collector.py
@@ -1,0 +1,90 @@
+"""PayPay証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "paypay"
+_mod = load_site_module(_CODE)
+PaypayCollector = _mod.PaypayCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, PaypayCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "PayPay証券"
+
+
+def test_is_logged_in_true(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    resp = MagicMock()
+    resp.status = 200
+    page.goto.return_value = resp
+    page.url = "https://www.paypay-sec.co.jp/trade/"
+    assert c._is_logged_in(page) is True
+
+
+def test_is_logged_in_false_on_redirect(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    resp = MagicMock()
+    resp.status = 200
+    page.goto.return_value = resp
+    page.url = "https://www.paypay-sec.co.jp/login"
+    assert c._is_logged_in(page) is False
+
+
+def test_collect_calls_login_when_not_logged_in(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_is_logged_in", return_value=False), \
+         patch.object(c, "_login") as mock_login, \
+         patch.object(c, "_navigate_to_documents"), \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result"):
+        c.collect()
+
+    mock_login.assert_called_once()
+
+
+def test_collect_skips_login_when_logged_in(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_is_logged_in", return_value=True), \
+         patch.object(c, "_login") as mock_login, \
+         patch.object(c, "_navigate_to_documents"), \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result"):
+        c.collect()
+
+    mock_login.assert_not_called()
+
+
+def test_collect_error_when_pdf_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_is_logged_in", return_value=True), \
+         patch.object(c, "_navigate_to_documents"), \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "error"

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -62,7 +62,7 @@ def test_wait_for_login(tmp_path):
     collector = _make_collector(tmp_path)
     page = MagicMock()
 
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(collector, "prompt", return_value=""):
         collector._wait_for_login(page)
 
     page.goto.assert_called_once_with(collector.config["login_url"])

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -273,6 +273,6 @@ def test_collect_skip_when_year_row_not_found(tmp_path):
          patch.object(collector, "_navigate_to_report_list"), \
          patch.object(collector, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        collector.collect()
+        collector.run()
 
     mock_log.assert_called_once_with("skip", [], f"{collector.config['target_year']}年の取引報告書が存在しません")

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -229,7 +229,7 @@ def test_download_files_no_xml_button(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     collector = _make_collector(tmp_path)
-    collector._convert_to_json(["data/foo.pdf"])
+    collector._convert_xml_to_json(["data/foo.pdf"])
     captured = capsys.readouterr()
     assert "スキップ" in captured.out
 
@@ -241,7 +241,7 @@ def test_convert_to_json_with_xml(tmp_path):
 
     collector = _make_collector(tmp_path)
     collector.output_dir.mkdir(parents=True, exist_ok=True)
-    collector._convert_to_json([str(fixture_xml)])
+    collector._convert_xml_to_json([str(fixture_xml)])
 
     json_path = collector.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -269,6 +269,7 @@ def test_collect_skip_when_year_row_not_found(tmp_path):
     with patch.object(collector, "launch_browser", return_value=page), \
          patch.object(collector, "close_browser"), \
          patch.object(collector, "_wait_for_login"), \
+         patch.object(collector, "_save_session_state"), \
          patch.object(collector, "_navigate_to_report_list"), \
          patch.object(collector, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):

--- a/tests/test_rakuten_collector.py
+++ b/tests/test_rakuten_collector.py
@@ -65,7 +65,7 @@ def test_wait_for_login(tmp_path):
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         collector._wait_for_login(page)
 
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(collector.config["login_url"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -29,7 +29,7 @@ def test_list_auto_companies():
 
 def test_all_companies_have_required_fields():
     registry = load_registry()
-    required = {"code", "name", "url", "has_xml", "マイナ連携", "collection"}
+    required = {"code", "name", "site_url", "has_xml", "マイナ連携", "collection"}
     for company in registry["securities"]:
         missing = required - company.keys()
         assert not missing, f"{company['code']} にフィールドが不足: {missing}"

--- a/tests/test_sawakami_collector.py
+++ b/tests/test_sawakami_collector.py
@@ -1,0 +1,79 @@
+"""さわかみ投信 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "sawakami"
+_mod = load_site_module(_CODE)
+SawakamiCollector = _mod.SawakamiCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, SawakamiCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "さわかみ投信"
+
+
+def test_is_logged_in_true(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    resp = MagicMock()
+    resp.status = 200
+    page.goto.return_value = resp
+    # ログイン済み: /e-delivery にいてログインフォームなし
+    page.url = "https://fv.sawakami.co.jp/e-delivery"
+    page.locator.return_value.count.return_value = 0
+    assert c._is_logged_in(page) is True
+
+
+def test_collect_calls_login_when_not_logged_in(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_is_logged_in", return_value=False), \
+         patch.object(c, "_login") as mock_login, \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result"):
+        c.collect()
+
+    mock_login.assert_called_once()
+
+
+def test_collect_skips_login_when_logged_in(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_is_logged_in", return_value=True), \
+         patch.object(c, "_login") as mock_login, \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result"):
+        c.collect()
+
+    mock_login.assert_not_called()
+
+
+def test_collect_error_when_pdf_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_is_logged_in", return_value=True), \
+         patch.object(c, "_download_pdf", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "error"

--- a/tests/test_sawakami_collector.py
+++ b/tests/test_sawakami_collector.py
@@ -44,7 +44,7 @@ def test_collect_calls_login_when_not_logged_in(tmp_path):
          patch.object(c, "_login") as mock_login, \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result"):
-        c.collect()
+        c.run()
 
     mock_login.assert_called_once()
 
@@ -59,7 +59,7 @@ def test_collect_skips_login_when_logged_in(tmp_path):
          patch.object(c, "_login") as mock_login, \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result"):
-        c.collect()
+        c.run()
 
     mock_login.assert_not_called()
 
@@ -73,7 +73,7 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "_is_logged_in", return_value=True), \
          patch.object(c, "_download_pdf", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "error"

--- a/tests/test_sbi_collector.py
+++ b/tests/test_sbi_collector.py
@@ -101,7 +101,7 @@ def test_collect_skip_when_report_not_found(tmp_path):
          patch.object(c, "_navigate_to_report_popup", return_value=popup), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_sbi_collector.py
+++ b/tests/test_sbi_collector.py
@@ -41,7 +41,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_wait_for_login_skips_when_logged_in(tmp_path):

--- a/tests/test_sbi_collector.py
+++ b/tests/test_sbi_collector.py
@@ -39,7 +39,7 @@ def test_year_month_patterns():
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 
@@ -48,9 +48,9 @@ def test_wait_for_login_skips_when_logged_in(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
     page.locator.return_value.count.return_value = 0  # no username input = logged in
-    with patch("builtins.input") as mock_input:
+    with patch.object(c, "prompt") as mock_prompt:
         c._wait_for_login(page)
-    mock_input.assert_not_called()
+    mock_prompt.assert_not_called()
 
 
 def test_find_report_row_button_found(tmp_path):

--- a/tests/test_sbi_collector.py
+++ b/tests/test_sbi_collector.py
@@ -73,7 +73,7 @@ def test_find_report_row_button_not_found(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     c = _make(tmp_path)
-    c._convert_to_json(["data/foo.pdf"])
+    c._convert_xml_to_json(["data/foo.pdf"])
     assert "スキップ" in capsys.readouterr().out
 
 
@@ -82,7 +82,7 @@ def test_convert_to_json_with_xml(tmp_path):
         pytest.skip("teg204_sample.xml が存在しない")
     c = _make(tmp_path)
     c.output_dir.mkdir(parents=True, exist_ok=True)
-    c._convert_to_json([str(FIXTURE_XML)])
+    c._convert_xml_to_json([str(FIXTURE_XML)])
     json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))

--- a/tests/test_sbi_collector.py
+++ b/tests/test_sbi_collector.py
@@ -44,6 +44,15 @@ def test_wait_for_login(tmp_path):
     page.goto.assert_called_once_with(_mod._LOGIN_URL)
 
 
+def test_wait_for_login_skips_when_logged_in(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    page.locator.return_value.count.return_value = 0  # no username input = logged in
+    with patch("builtins.input") as mock_input:
+        c._wait_for_login(page)
+    mock_input.assert_not_called()
+
+
 def test_find_report_row_button_found(tmp_path):
     c = _make(tmp_path, year=2025)
     popup = MagicMock()

--- a/tests/test_sbi_collector.py
+++ b/tests/test_sbi_collector.py
@@ -1,0 +1,98 @@
+"""SBI証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import FIXTURE_XML, build_collector, load_site_module
+
+_CODE = "sbi"
+_mod = load_site_module(_CODE)
+SBICollector = _mod.SBICollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, SBICollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "SBI証券"
+    assert c.config["target_year"] == 2025
+
+
+def test_year_param(tmp_path):
+    c = _make(tmp_path, year=2024)
+    assert c.config["target_year"] == 2024
+
+
+def test_year_month_patterns():
+    patterns = _mod._year_month_patterns(2025)
+    assert "2025/12" in patterns
+    assert "2026/01" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_find_report_row_button_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    popup = MagicMock()
+    btn = MagicMock()
+    btn.count.return_value = 1
+    popup.get_by_role.return_value.filter.return_value = btn
+    result = c._find_report_row_button(popup, 2025)
+    assert result is btn.first
+
+
+def test_find_report_row_button_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    popup = MagicMock()
+    popup.get_by_role.return_value.filter.return_value.count.return_value = 0
+    result = c._find_report_row_button(popup, 2025)
+    assert result is None
+
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    c = _make(tmp_path)
+    c._convert_to_json(["data/foo.pdf"])
+    assert "スキップ" in capsys.readouterr().out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    if not FIXTURE_XML.exists():
+        pytest.skip("teg204_sample.xml が存在しない")
+    c = _make(tmp_path)
+    c.output_dir.mkdir(parents=True, exist_ok=True)
+    c._convert_to_json([str(FIXTURE_XML)])
+    json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == _CODE
+
+
+def test_collect_skip_when_report_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    popup = MagicMock()
+    popup.get_by_role.return_value.filter.return_value.count.return_value = 0
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_report_popup", return_value=popup), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -99,7 +99,7 @@ def test_collect_skip_when_xml_link_not_found(tmp_path):
          patch.object(c, "_find_xml_link", return_value=None), \
          patch.object(c, "log_result") as mock_log, \
          patch.object(_mod, "_wait"):
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -39,6 +39,16 @@ def test_wait_for_login(tmp_path):
     page.goto.assert_called_once_with(_mod._LOGIN_URL)
 
 
+def test_wait_for_login_skips_when_logged_in(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    page.url = "https://trade.smbcnikko.co.jp/Trade/0/top/"
+    with patch("builtins.input") as mock_input:
+        c._wait_for_login(page)
+    mock_input.assert_not_called()
+    assert c._session is page
+
+
 def test_find_xml_link_found(tmp_path):
     c = _make(tmp_path, year=2025)
     session = MagicMock()

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -1,0 +1,94 @@
+"""SMBC日興証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import FIXTURE_XML, build_collector, load_site_module
+
+_CODE = "smbcnikko"
+_mod = load_site_module(_CODE)
+SMBCNikkoCollector = _mod.SMBCNikkoCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, SMBCNikkoCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "SMBC日興証券"
+
+
+def test_year_month_patterns_instance(tmp_path):
+    # smbcnikko は _year_month_patterns がインスタンスメソッド
+    c = _make(tmp_path)
+    patterns = c._year_month_patterns(2025)
+    assert "2025/12" in patterns
+    assert "2026/01" in patterns
+
+
+def test_wait_for_login(tmp_path):
+    c = _make(tmp_path)
+    page = MagicMock()
+    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+        c._wait_for_login(page)
+    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+
+
+def test_find_xml_link_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    session = MagicMock()
+    row = MagicMock()
+    row.count.return_value = 1
+    # locator("tr").filter(...).filter(...) → row
+    session.locator.return_value.filter.return_value.filter.return_value = row
+    result = c._find_xml_link(session, 2025)
+    assert result is row.first.locator.return_value.first
+
+
+def test_find_xml_link_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    session = MagicMock()
+    session.locator.return_value.filter.return_value.filter.return_value.count.return_value = 0
+    result = c._find_xml_link(session, 2025)
+    assert result is None
+
+
+def test_convert_to_json_skips_without_xml(tmp_path, capsys):
+    c = _make(tmp_path)
+    c._convert_to_json(["data/foo.pdf"])
+    assert "スキップ" in capsys.readouterr().out
+
+
+def test_convert_to_json_with_xml(tmp_path):
+    if not FIXTURE_XML.exists():
+        pytest.skip("teg204_sample.xml が存在しない")
+    c = _make(tmp_path)
+    c.output_dir.mkdir(parents=True, exist_ok=True)
+    c._convert_to_json([str(FIXTURE_XML)])
+    json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["code"] == _CODE
+
+
+def test_collect_skip_when_xml_link_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    c._session = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_navigate_to_report_list"), \
+         patch.object(c, "_find_xml_link", return_value=None), \
+         patch.object(c, "log_result") as mock_log, \
+         patch.object(_mod, "_wait"):
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -70,7 +70,7 @@ def test_find_xml_link_not_found(tmp_path):
 
 def test_convert_to_json_skips_without_xml(tmp_path, capsys):
     c = _make(tmp_path)
-    c._convert_to_json(["data/foo.pdf"])
+    c._convert_xml_to_json(["data/foo.pdf"])
     assert "スキップ" in capsys.readouterr().out
 
 
@@ -79,7 +79,7 @@ def test_convert_to_json_with_xml(tmp_path):
         pytest.skip("teg204_sample.xml が存在しない")
     c = _make(tmp_path)
     c.output_dir.mkdir(parents=True, exist_ok=True)
-    c._convert_to_json([str(FIXTURE_XML)])
+    c._convert_xml_to_json([str(FIXTURE_XML)])
     json_path = c.output_dir.parent / "nenkantorihikihokokusho.json"
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -36,7 +36,7 @@ def test_wait_for_login(tmp_path):
     page = MagicMock()
     with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
         c._wait_for_login(page)
-    page.goto.assert_called_once_with(_mod._LOGIN_URL)
+    page.goto.assert_called_once_with(c.config["login_url"])
 
 
 def test_wait_for_login_skips_when_logged_in(tmp_path):

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -84,6 +84,7 @@ def test_collect_skip_when_xml_link_not_found(tmp_path):
     with patch.object(c, "launch_browser", return_value=page), \
          patch.object(c, "close_browser"), \
          patch.object(c, "_wait_for_login"), \
+         patch.object(c, "_save_session_state"), \
          patch.object(c, "_navigate_to_report_list"), \
          patch.object(c, "_find_xml_link", return_value=None), \
          patch.object(c, "log_result") as mock_log, \

--- a/tests/test_smbcnikko_collector.py
+++ b/tests/test_smbcnikko_collector.py
@@ -34,7 +34,7 @@ def test_year_month_patterns_instance(tmp_path):
 def test_wait_for_login(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
-    with patch.object(_mod, "_wait"), patch("builtins.input", return_value=""):
+    with patch.object(_mod, "_wait"), patch.object(c, "prompt", return_value=""):
         c._wait_for_login(page)
     page.goto.assert_called_once_with(c.config["login_url"])
 
@@ -43,9 +43,9 @@ def test_wait_for_login_skips_when_logged_in(tmp_path):
     c = _make(tmp_path)
     page = MagicMock()
     page.url = "https://trade.smbcnikko.co.jp/Trade/0/top/"
-    with patch("builtins.input") as mock_input:
+    with patch.object(c, "prompt") as mock_prompt:
         c._wait_for_login(page)
-    mock_input.assert_not_called()
+    mock_prompt.assert_not_called()
     assert c._session is page
 
 

--- a/tests/test_tsumiki_collector.py
+++ b/tests/test_tsumiki_collector.py
@@ -1,0 +1,88 @@
+"""tsumiki証券 収集スクリプトのユニットテスト（Playwright モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "tsumiki"
+_mod = load_site_module(_CODE)
+TsumikiCollector = _mod.TsumikiCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, TsumikiCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "tsumiki証券"
+
+
+def test_handle_otp_skips_when_no_field(tmp_path):
+    c = _make(tmp_path)
+    page1 = MagicMock()
+    page1.get_by_role.return_value.count.return_value = 0
+    result = c._handle_otp(page1)
+    assert result is True
+
+
+def test_handle_otp_returns_false_on_empty_input(tmp_path):
+    c = _make(tmp_path)
+    page1 = MagicMock()
+    otp_field = MagicMock()
+    otp_field.count.return_value = 1
+    page1.get_by_role.return_value = otp_field
+    with patch("builtins.input", return_value=""):
+        result = c._handle_otp(page1)
+    assert result is False
+
+
+def test_handle_otp_submits_code(tmp_path):
+    c = _make(tmp_path)
+    page1 = MagicMock()
+    otp_field = MagicMock()
+    otp_field.count.return_value = 1
+    page1.get_by_role.return_value = otp_field
+    with patch("builtins.input", return_value="123456"), patch.object(_mod, "_wait"):
+        result = c._handle_otp(page1)
+    assert result is True
+    otp_field.fill.assert_called_once_with("123456")
+
+
+def test_collect_skip_when_otp_cancelled(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_login", return_value=page1), \
+         patch.object(c, "_navigate_to_reports"), \
+         patch.object(c, "_handle_otp", return_value=False), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "skip"
+
+
+def test_collect_error_when_pdf_not_found(tmp_path):
+    c = _make(tmp_path, year=2025)
+    page = MagicMock()
+    page1 = MagicMock()
+
+    with patch.object(c, "launch_browser", return_value=page), \
+         patch.object(c, "close_browser"), \
+         patch.object(c, "_login", return_value=page1), \
+         patch.object(c, "_navigate_to_reports"), \
+         patch.object(c, "_handle_otp", return_value=True), \
+         patch.object(c, "_download_pdf_via_route", return_value=None), \
+         patch.object(c, "log_result") as mock_log:
+        c.collect()
+
+    assert mock_log.called
+    assert mock_log.call_args[0][0] == "error"

--- a/tests/test_tsumiki_collector.py
+++ b/tests/test_tsumiki_collector.py
@@ -64,7 +64,7 @@ def test_collect_skip_when_otp_cancelled(tmp_path):
          patch.object(c, "_navigate_to_reports"), \
          patch.object(c, "_handle_otp", return_value=False), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "skip"
@@ -82,7 +82,7 @@ def test_collect_error_when_pdf_not_found(tmp_path):
          patch.object(c, "_handle_otp", return_value=True), \
          patch.object(c, "_download_pdf_via_route", return_value=None), \
          patch.object(c, "log_result") as mock_log:
-        c.collect()
+        c.run()
 
     assert mock_log.called
     assert mock_log.call_args[0][0] == "error"

--- a/tests/test_tsumiki_collector.py
+++ b/tests/test_tsumiki_collector.py
@@ -30,27 +30,17 @@ def test_handle_otp_skips_when_no_field(tmp_path):
     assert result is True
 
 
-def test_handle_otp_returns_false_on_empty_input(tmp_path):
+def test_handle_otp_waits_for_field_detached(tmp_path):
+    """OTPフィールドが表示された場合、wait_for(state='detached') を呼び出す"""
     c = _make(tmp_path)
     page1 = MagicMock()
     otp_field = MagicMock()
     otp_field.count.return_value = 1
     page1.get_by_role.return_value = otp_field
-    with patch.object(c, "prompt", return_value=""):
-        result = c._handle_otp(page1)
-    assert result is False
-
-
-def test_handle_otp_submits_code(tmp_path):
-    c = _make(tmp_path)
-    page1 = MagicMock()
-    otp_field = MagicMock()
-    otp_field.count.return_value = 1
-    page1.get_by_role.return_value = otp_field
-    with patch.object(c, "prompt", return_value="123456"), patch.object(_mod, "_wait"):
+    with patch.object(_mod, "_wait"):
         result = c._handle_otp(page1)
     assert result is True
-    otp_field.fill.assert_called_once_with("123456")
+    otp_field.wait_for.assert_called_once_with(state="detached", timeout=300_000)
 
 
 def test_collect_skip_when_otp_cancelled(tmp_path):

--- a/tests/test_tsumiki_collector.py
+++ b/tests/test_tsumiki_collector.py
@@ -36,7 +36,7 @@ def test_handle_otp_returns_false_on_empty_input(tmp_path):
     otp_field = MagicMock()
     otp_field.count.return_value = 1
     page1.get_by_role.return_value = otp_field
-    with patch("builtins.input", return_value=""):
+    with patch.object(c, "prompt", return_value=""):
         result = c._handle_otp(page1)
     assert result is False
 
@@ -47,7 +47,7 @@ def test_handle_otp_submits_code(tmp_path):
     otp_field = MagicMock()
     otp_field.count.return_value = 1
     page1.get_by_role.return_value = otp_field
-    with patch("builtins.input", return_value="123456"), patch.object(_mod, "_wait"):
+    with patch.object(c, "prompt", return_value="123456"), patch.object(_mod, "_wait"):
         result = c._handle_otp(page1)
     assert result is True
     otp_field.fill.assert_called_once_with("123456")

--- a/tests/test_webull_collector.py
+++ b/tests/test_webull_collector.py
@@ -1,0 +1,71 @@
+"""ウィブル証券 収集スクリプトのユニットテスト（ADB モック）"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_collector, load_site_module
+
+_CODE = "webull"
+_mod = load_site_module(_CODE)
+WebullCollector = _mod.WebullCollector
+
+
+def _make(tmp_path, year=2025):
+    return build_collector(tmp_path, _CODE, WebullCollector, year)
+
+
+def test_init(tmp_path):
+    c = _make(tmp_path)
+    assert c.code == _CODE
+    assert c.name == "ウィブル証券"
+
+
+def test_find_adb_serial_found(tmp_path):
+    c = _make(tmp_path)
+    adb_output = "List of devices attached\n192.168.1.10:5555\tdevice\n"
+    with patch.object(_mod, "_adb", return_value=adb_output):
+        serial = c._find_adb_serial()
+    assert serial == "192.168.1.10:5555"
+
+
+def test_find_adb_serial_not_found(tmp_path):
+    c = _make(tmp_path)
+    adb_output = "List of devices attached\n"
+    with patch.object(_mod, "_adb", return_value=adb_output):
+        with pytest.raises(RuntimeError, match="ADB デバイスが見つかりません"):
+            c._find_adb_serial()
+
+
+def test_find_adb_serial_unauthorized(tmp_path):
+    c = _make(tmp_path)
+    adb_output = "List of devices attached\nabc123\tunauthorized\n"
+    with patch.object(_mod, "_adb", return_value=adb_output):
+        with pytest.raises(RuntimeError, match="ADB デバイスが見つかりません"):
+            c._find_adb_serial()
+
+
+def test_snapshot_combines_dirs(tmp_path):
+    c = _make(tmp_path)
+
+    def adb_ls_side(*args):
+        if "/sdcard/Documents" in args:
+            return "file1.pdf\nfile2.pdf"
+        if "/sdcard/Download" in args:
+            return "file3.pdf"
+        return ""
+
+    with patch.object(_mod, "_adb", side_effect=adb_ls_side):
+        result = c._snapshot()
+
+    assert any("file1.pdf" in p for p in result)
+    assert any("file3.pdf" in p for p in result)
+
+
+def test_collect_raises_without_uiautomator2(tmp_path):
+    c = _make(tmp_path, year=2025)
+    with patch.object(_mod, "_adb", return_value="List of devices attached\nabc\tdevice"), \
+         patch.dict("sys.modules", {"uiautomator2": None}):
+        with pytest.raises(SystemExit):
+            c.collect()


### PR DESCRIPTION
## Summary

#34 tax-collect 全社コードレビュー対応の最終版。Opus レビュー指摘の対処、共通化リファクタ、テスト整備、不具合修正、新規ツール追加を含む大規模変更。

## 主要な変更

### 不具合修正
- **B-1〜B-3**: monex dead code、webull ADB ハードコード、gmo-click expect_popup タイムアウト
- **hifumi**: ログイン URL 待機を要素 visible 待機に変更（cookie 復元時の早期通過防止）/ shishyobakoRedirect href ロケート / 複数 PDF ボタン併存時の hidden 誤選択回避
- **tsumiki**: 報告書ボタン取得を `<div role=\"button\">` 対応に修正
- **paypay**: ログイン画面とトップページの「行き来」修正（既に /login/ にいる時 top 経由スキップ）

### 全社共通改善
- **B-4**: PDF マジックバイト検証を `BaseCollector.verify_pdf()` に共通化
- **M-1/M-2/M-3**: storage_state 保存・cookie 空保護・ログイン済み判定の共通化
- **R-1〜R-6**: utils 共通化（_wait/extract_filename/eshishobako PDF 捕捉/JSON 変換等）
- **D-1〜D-5**: sys.path ハック削除・site.json 集約・CLI 化・prompt() 廃止
- **全社 main()**: `sys.exit(collector.run())` 化 → run.py の returncode 判定が正しく動作

### 新規ツール
- **recorder.py**: 新規サイト追加用 操作記録ツール（trace/HAR/event/DOM 採取）
- **convert.py**: PDF→JSON 変換を収集と分離・直列化（Gemini API レート対策）

### テスト
- 全 15 社のユニットテスト整備 (271 passed)

## Test plan

- [x] hifumi 実機テスト → PDF 取得成功
- [x] tsumiki 実機テスト → PDF 取得成功
- [x] paypay 実機テスト → PDF 取得成功（行き来挙動解消）
- [x] 全社 unit test 271 passed
- [ ] master マージ後、全社一括収集で最終確認

## 関連資料

- プラン: [plan/20260424_0006_tax-collect-code-review.md](../blob/feature/34_tax-collect-code-review/plan/20260424_0006_tax-collect-code-review.md)

Closes #34