### PR TITLE
feat: #36 セゾン投信 特定口座年間取引報告書 自動収集スクリプト追加

### DIFF
--- a/plan/20260426_1212_issue36_saison-am-collect.md
+++ b/plan/20260426_1212_issue36_saison-am-collect.md
@@ -1,8 +1,8 @@
-# #36 セゾン投信 特定口座年間取引報告書 自動収集スクリプト実装
+# #36 セゾン投信 特定口座年間取引報告書 自動収集スクリプト実装 [完了 PR#38 2026-04-27]
 
 ## 対象 issue
 
-[#36](https://github.com/genba-neko/agent-skills-money-ops/issues/35)
+[#36](https://github.com/genba-neko/agent-skills-money-ops/issues/36)
 
 ---
 

--- a/plan/20260426_1212_issue36_saison-am-collect.md
+++ b/plan/20260426_1212_issue36_saison-am-collect.md
@@ -1,0 +1,94 @@
+# #36 セゾン投信 特定口座年間取引報告書 自動収集スクリプト実装
+
+## 対象 issue
+
+[#36](https://github.com/genba-neko/agent-skills-money-ops/issues/35)
+
+---
+
+## 背景
+
+セゾン投信（saison-am）は tax-collect 未対応。Webアプリ＋電子バト（denshi-bato）系のPDF配信システムを使用。`recorder.py` でフロー調査済み。
+
+---
+
+## 操作データ（recorder 出力）
+
+`output/recorder/saison-am/20260426_120247/`
+- `summary.md` — URL 推移・popup・download 要約
+- `events.jsonl` — 全イベント時系列
+- `network.har` — リクエスト・レスポンス・cookie
+- `trace.zip` — Playwright Trace Viewer 用
+- `dom_*.html` — milestone 地点 DOM
+
+---
+
+## フロー（実測）
+
+```
+www.saison-am.co.jp (トップ)
+  ↓ ログイン
+  popup: app.saison-am.co.jp/mypage  (会員ページ)
+  ↓ 取引 → 取引パスワード入力
+  popup: trade.saison-am.co.jp/webbroker3/Web3SZApp?SZkey=...
+  ↓
+  popup: w37.denshi-bato.webbroker.jp/seciss/denshibato
+         ?REPORTTYPE=3&SERCHPDF=2025/12/31
+  ↓ PDFファイル取得
+  download: 270582202512313_YYYYMMDDHHMMSS.pdf
+```
+
+---
+
+## 実装方針
+
+### popup チェーン管理
+
+4 段階の popup 遷移:
+1. `www.saison-am.co.jp` → `app.saison-am.co.jp/mypage` （ログイン後）
+2. `app.saison-am.co.jp` → `trade.saison-am.co.jp/webbroker3/Web3SZApp` （取引パスワード）
+3. `trade.saison-am.co.jp` → `w37.denshi-bato.webbroker.jp/seciss/denshibato`
+4. PDF download
+
+各 popup は `expect_popup()` で待機（CDP イベントポンプ維持）。
+
+### 手動介入ポイント
+
+- ログイン（ID/PW）
+- 取引パスワード（page2）
+- 二段階認証（必要時）
+
+→ `wait_for_url("**/app.saison-am.co.jp/mypage**", timeout=300_000)` でログイン完了検知
+
+### PDF 取得方式
+
+- 配信元: `w37.denshi-bato.webbroker.jp/seciss/denshibato`
+- e-shishobako（hifumi 等）と類似アーキテクチャ → `capture_dpaw_pdf` 流用検討
+- ただし URL pattern 異なる可能性 → HAR で詳細確認後判定
+- クエリ: `REPORTTYPE=3` (年間取引報告書), `SERCHPDF=YYYY/12/31`
+
+### 報告書年度指定
+
+`SERCHPDF=2025/12/31` を `--year` 引数から組み立て。
+
+---
+
+## 実装タスク
+
+1. `skills/tax-collect/sites/saison-am/` ディレクトリ作成
+2. `site.json` 作成（login_url, target_year 等）
+3. `collect.py` 作成（BaseCollector 継承）
+   - `_wait_for_login`
+   - `_navigate_to_denshibato` （popup 4 段階）
+   - PDF 捕捉（capture_dpaw_pdf or 専用実装）
+4. `registry.json` に saison-am 追加（collection: auto）
+5. 動作確認（`python skills/tax-collect/sites/saison-am/collect.py --year 2025`）
+6. 一括ランナー経由確認（`python skills/tax-collect/run.py --sites saison-am --year 2025`）
+
+---
+
+## 参考
+
+- recorder 出力: `output/recorder/saison-am/20260426_120247/`
+- 類似実装: `skills/tax-collect/sites/hifumi/collect.py`（e-shishobako）
+- 共通モジュール: `src/money_ops/collector/eshishobako.py`（capture_dpaw_pdf）

--- a/skills/tax-collect/registry.json
+++ b/skills/tax-collect/registry.json
@@ -215,6 +215,20 @@
       "login_detection": {
         "custom": true
       }
+    },
+    {
+      "code": "saison-am",
+      "name": "セゾン投信",
+      "document_type": "特定口座年間取引報告書",
+      "site_url": "https://www.saison-am.co.jp/",
+      "login_url": null,
+      "dashboard_url": null,
+      "has_xml": false,
+      "マイナ連携": false,
+      "collection": "auto",
+      "login_detection": {
+        "custom": true
+      }
     }
   ]
 }

--- a/skills/tax-collect/sites/saison-am/collect.py
+++ b/skills/tax-collect/sites/saison-am/collect.py
@@ -1,0 +1,252 @@
+"""セゾン投信 特定口座年間取引報告書（PDF）Playwright 収集スクリプト
+
+使い方:
+    python collect.py [--year YYYY]
+
+環境変数:
+    HEADLESS    true/false（デフォルト: false）
+    DEBUG       true/false（デフォルト: false）
+
+注意:
+    ログイン・取引パスワード入力は人間が手動で行う。
+    スクリプト起動後、ブラウザで mypage 到達まで操作してください。
+
+実測済みポップアップ構造（recorder 確認）:
+    page:        セゾン投信 トップ（www.saison-am.co.jp）
+    mypage:      会員ページ（app.saison-am.co.jp/mypage）— popup
+    trade_page:  取引画面（trade.saison-am.co.jp/webbroker3/Web3App）— popup（中継）
+    denshibato:  電子バト 報告書一覧（w37.denshi-bato.webbroker.jp/seciss/denshibato）— popup
+
+PDF 取得方式:
+    1. mypage の「報告書閲覧」div クリック → 連鎖 popup（trade → denshibato）
+    2. denshibato の <a href="javascript:subPdf('YYYY/12/31','0')"> クリック
+    3. download イベント捕捉 → 保存
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from money_ops.collector.base import BaseCollector
+from money_ops.utils import wait as _wait
+
+_SITE_JSON = Path(__file__).parent / "site.json"
+
+
+class SaisonAmCollector(BaseCollector):
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None, headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
+
+    def _wait_for_login(self, page) -> object:
+        """top → 「ログイン」link クリック → popup app.saison-am.co.jp → ホーム描画完了待ち
+        → 「マイページ」ナビクリック → /mypage 遷移。
+
+        recorder + 実機確認:
+          - top の「ログイン」link は target="_blank" で popup 開く
+          - popup は OAuth 経由で app.saison-am.co.jp/?tab=0（ホーム）に着地
+          - ホーム下部ナビに「マイページ」link あり → クリックで /mypage
+          - /mypage に「報告書閲覧」div あり
+        """
+        page.goto(self.config["login_url"])
+        page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+
+        with page.expect_popup() as popup_info:
+            page.get_by_role("link", name="ログイン").first.click()
+        home = popup_info.value
+        home.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+        self.dlog(f"popup URL (初期): {home.url}")
+
+        print(f"[{self.name}] popup でログインしてください（最大5分）")
+        # ログイン完了 = 下部ナビの「マイページ」link が visible
+        # （URL 待機ではセッション cookie 残存時に早期通過する可能性あり）
+        mypage_nav = home.get_by_role("link", name="マイページ")
+        mypage_nav.first.wait_for(state="visible", timeout=300_000)
+        _wait(2.0, 3.0)
+        self.dlog(f"home URL: {home.url}")
+        self.save_html(home, "home")
+
+        # 「マイページ」ナビをクリックして /mypage へ
+        print(f"[{self.name}] マイページへ移動")
+        mypage_nav.first.click()
+        home.wait_for_url("**/mypage**", timeout=30_000)
+        _wait(1.5, 2.5)
+        # /mypage の「報告書閲覧」描画完了待機
+        home.locator("div.bg-white.pointer", has_text="報告書閲覧").first.wait_for(
+            state="visible", timeout=30_000
+        )
+        self.dlog(f"mypage URL: {home.url}")
+        self.save_html(home, "mypage")
+
+        self._save_session_state(page)
+
+        return home
+
+    def _open_denshibato_menu(self, mypage) -> object:
+        """mypage の「報告書閲覧」div クリック → popup → trade.saison-am 経由で
+        denshi-bato/secdoc/newdenshibato（電子交付サービスメニュー）まで到達。
+
+        recorder 確認済み popup 遷移:
+          trade.saison-am.co.jp/Web3SZApp（中継・即座に閉じる可能性）
+          → trade.saison-am.co.jp/Web3App
+          → w37.denshi-bato.webbroker.jp/secdoc/newdenshibato（メニュー画面）
+
+        中継 popup が target 消失で expect_popup/wait_for_url が "Target closed" を投げる
+        ため、context.pages を polling して denshi-bato URL の page を探す方式に変更。
+        """
+        print(f"[{self.name}] 報告書閲覧 → 電子交付メニュー（trade.saison-am 中継のため最大 10分）")
+        # trace 解析確定: click → popup 作成（trade.saison-am）→ ~5分後に denshi-bato 遷移
+        # Playwright 公式 API（expect_event + wait_for_url）で清書
+        with mypage.context.expect_event("page", timeout=60_000) as page_info:
+            mypage.locator("div.bg-white.pointer", has_text="報告書閲覧").first.click()
+        menu_page = page_info.value
+        self.dlog(f"popup 作成 URL: {menu_page.url}")
+        # denshi-bato に遷移するまで待機（trade.saison-am 中継 処理時間考慮で 10分）
+        menu_page.wait_for_url(lambda u: "denshi-bato.webbroker.jp" in u, timeout=600_000)
+        self.dlog(f"denshi-bato 到達: {menu_page.url}")
+
+        menu_page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+        self.dlog(f"denshi-bato メニュー URL (描画完了): {menu_page.url}")
+        self.save_html(menu_page, "denshibato_menu")
+        return menu_page
+
+    def _open_report_list(self, menu_page) -> object:
+        """電子交付メニュー → 「取引残高報告書・年間取引報告書...」link →
+        検索条件画面（報告書種類 + 対象年月種別 + 検索）→ list 画面。
+
+        実機 HTML 確認:
+          - select[0] 報告書種類: value="3" = 年間取引報告書
+          - select[1] 対象年月種別: value="3" = 5年前からの取引（過去分も含む範囲）
+            （年間取引報告書の作成日は target_year/12/31 or target_year+1/01/xx の
+            どちらかでパターン不定 + 過去年度の報告書も検索可能にするため 5年範囲）
+          - 検索 link click → 結果一覧画面
+        """
+        print(f"[{self.name}] 「年間取引報告書」メニューへ")
+        report_link = menu_page.locator("a", has_text="年間取引報告書")
+        if report_link.count() == 0:
+            self.dlog("「年間取引報告書」link が見つかりません")
+            return None
+        report_link.first.click()
+        menu_page.wait_for_url(lambda u: "seciss/denshibato" in u, timeout=30_000)
+        menu_page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+        self.save_html(menu_page, "denshibato_search")
+
+        # 検索条件: 年間取引報告書 + 5年前からの取引（過去分カバー）
+        print(f"[{self.name}] 検索条件: 年間取引報告書 / 5年前から")
+        selects = menu_page.locator("select")
+        selects.nth(0).select_option(value="3")  # 報告書種類: 年間取引報告書
+        _wait(0.3, 0.7)
+        selects.nth(1).select_option(value="3")  # 対象年月種別: 5年前からの取引
+        _wait(0.3, 0.7)
+
+        # 検索 link click（onclick="subInputForm()"）
+        menu_page.get_by_role("link", name="検索").click()
+        menu_page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+
+        # 結果一覧: subPdf link が描画されるまで待機
+        menu_page.locator("a[href*='subPdf']").first.wait_for(state="visible", timeout=15_000)
+        self.dlog(f"報告書一覧 URL: {menu_page.url}")
+        self.save_html(menu_page, "denshibato_list")
+        return menu_page
+
+    def _download_pdf(self, list_page) -> str | None:
+        """seciss/denshibato で subPdf JavaScript link クリック → 新 popup B から
+        download イベント発火 → context.on("download") で全 page 対象に捕捉。
+
+        recorder 確認済み:
+          - <a href="javascript:subPdf('YYYY/12/31','0')"> でリンク
+          - クリック → 新規 popup B が開く → popup B が download トリガー
+          - suggested_filename = NNNNNNNNNNNNN_YYYYMMDDHHMMSS.pdf
+
+        実装:
+          context.expect_event("download") は document されておらず動作不確実。
+          確実な context.on("download", handler) で事前登録 → click → polling で待つ。
+        """
+        # 年間取引報告書の作成日は target_year/12/31 or target_year+1/01/xx
+        # （hifumi と同じく 2 パターン試行）
+        target_year = self.config["target_year"]
+        date_patterns = [f"{target_year}/12", f"{target_year + 1}/01"]
+        link = None
+        for pat in date_patterns:
+            candidate = list_page.locator(f"a[href*=\"subPdf('{pat}\"]")
+            if candidate.count() > 0:
+                self.dlog(f"subPdf link 発見: pattern={pat}")
+                link = candidate
+                break
+        if link is None:
+            self.dlog(f"subPdf link が見つかりません（パターン: {date_patterns}）")
+            return None
+
+        # subPdf click → popup B（PDF viewer）開く → URL 取得 → close
+        # （Chromium 内蔵 PDF viewer は download イベント発火しないため
+        #   popup URL を取得して page.request.get で直接 fetch する paypay 方式）
+        with list_page.expect_popup(timeout=30_000) as popup_info:
+            link.first.click()
+        pdf_popup = popup_info.value
+        try:
+            pdf_popup.wait_for_load_state("domcontentloaded", timeout=30_000)
+        except Exception as e:
+            self.dlog(f"PDF popup load 待機失敗（URL は取れる可能性あり）: {e}")
+        pdf_url = pdf_popup.url
+        self.dlog(f"PDF URL: {pdf_url}")
+        try:
+            pdf_popup.close()
+        except Exception:
+            pass
+
+        if "denshibato" not in pdf_url or "SERCHPDF" not in pdf_url:
+            self.dlog(f"PDF URL が想定外: {pdf_url}")
+            return None
+
+        # request.get で PDF bytes 直接取得（context cookie 共有）
+        response = list_page.request.get(pdf_url)
+        pdf_bytes = response.body()
+        if not pdf_bytes or pdf_bytes[:4] != b"%PDF":
+            self.dlog(f"PDF でないレスポンス: {len(pdf_bytes)} bytes, "
+                      f"CT={response.headers.get('content-type', '?')}")
+            return None
+
+        self.prepare_directory()
+        filename = f"{target_year}_saison-am_nentori.pdf"
+        pdf_path = self.output_dir / filename
+        pdf_path.write_bytes(pdf_bytes)
+        if not self.verify_pdf(pdf_path):
+            return None
+        print(f"[{self.name}] PDF 保存: {pdf_path}")
+        return str(pdf_path)
+
+    def _collect_core(self, page) -> None:
+        mypage = self._wait_for_login(page)
+        menu_page = self._open_denshibato_menu(mypage)
+        list_page = self._open_report_list(menu_page)
+        if list_page is None:
+            self.log_result("error", [], "報告書一覧画面への遷移失敗")
+            return
+
+        pdf_path = self._download_pdf(list_page)
+        if pdf_path is None:
+            self.log_result("error", [], "PDF 取得失敗")
+            return
+
+        self._queue_pdf_to_json(pdf_path, [str(Path(pdf_path).name)])
+        self.log_result("success", [pdf_path])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="セゾン投信 特定口座年間取引報告書収集")
+    parser.add_argument("--year", type=int, default=None, help="対象年度（例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
+    args = parser.parse_args()
+    collector = SaisonAmCollector(year=args.year, headless=args.headless, debug=args.debug)
+    sys.exit(collector.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tax-collect/sites/saison-am/site.json
+++ b/skills/tax-collect/sites/saison-am/site.json
@@ -1,0 +1,13 @@
+{
+  "name": "セゾン投信",
+  "code": "saison-am",
+  "target_year": 2025,
+  "output_dir": "data/income/securities/saison-am/2025/raw/",
+  "documents": [
+    {
+      "type": "特定口座年間取引報告書"
+    }
+  ],
+  "login_url": "https://www.saison-am.co.jp/",
+  "converter_type": "pdf_llm"
+}

--- a/src/money_ops/collector/base.py
+++ b/src/money_ops/collector/base.py
@@ -23,6 +23,11 @@ def _is_debug() -> bool:
     return os.environ.get("DEBUG", "false").lower() == "true"
 
 
+def _is_trace() -> bool:
+    """TRACE=true で Playwright trace.zip + network.har を採取（診断用）"""
+    return os.environ.get("TRACE", "false").lower() == "true"
+
+
 class BaseCollector:
     def __init__(
         self,
@@ -39,6 +44,8 @@ class BaseCollector:
         self.debug: bool = debug if debug is not None else _is_debug()
         self._debug_seq: int = 0  # HTML採取連番
         self._final_status: str | None = None  # 最終 log_result の status を保持（exit code 判定用）
+        self.trace: bool = _is_trace()
+        self._trace_dir: Path | None = None
         if year is not None:
             self.config["target_year"] = year
             self.config["output_dir"] = f"data/income/securities/{self.code}/{year}/raw/"
@@ -115,19 +122,31 @@ class BaseCollector:
         if any(profile_dir.iterdir()):
             print(f"[{self.name}] ブラウザプロファイル復元: {profile_dir}")
 
+        # TRACE=true で診断用に trace.zip + HAR 採取
+        launch_kwargs: dict = {
+            "headless": self.headless,
+            "args": [
+                "--disable-blink-features=AutomationControlled",
+                "--use-angle=d3d11",
+            ],
+            "ignore_default_args": ["--enable-automation"],
+        }
+        if self.trace:
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self._trace_dir = Path("output") / "trace" / self.code / ts
+            self._trace_dir.mkdir(parents=True, exist_ok=True)
+            launch_kwargs["record_har_path"] = str(self._trace_dir / "network.har")
+            print(f"[{self.name}] TRACE 有効: {self._trace_dir}")
+
         # persistent context でブラウザ全状態（cookies・IndexedDB・端末登録等）を永続化
         # --use-angle=d3d11 で実機 GPU（DirectX11）を使い Canvas/WebGL フィンガープリントを実機 Chrome と一致させる
         # （デフォルトの SwiftShader はソフトウェアレンダラーのためフィンガープリントが毎回異なり
         #   金融サイトのデバイス認識が通らない）
         self._context = self._playwright.chromium.launch_persistent_context(
-            str(profile_dir),
-            headless=self.headless,
-            args=[
-                "--disable-blink-features=AutomationControlled",
-                "--use-angle=d3d11",
-            ],
-            ignore_default_args=["--enable-automation"],
+            str(profile_dir), **launch_kwargs
         )
+        if self.trace:
+            self._context.tracing.start(screenshots=True, snapshots=True, sources=True)
         self._page = self._context.new_page()
         self._restore_session_cookies()
         # 全ページのナビゲーションをアクセスログに記録
@@ -165,6 +184,15 @@ class BaseCollector:
         print(f"[{self.name}] cookie {len(cookies)}件を復元しました")
 
     def close_browser(self) -> None:
+        # tracing 停止（context.close() より前に呼ぶ必要あり）
+        if self.trace and hasattr(self, "_context") and self._trace_dir is not None:
+            try:
+                trace_path = self._trace_dir / "trace.zip"
+                self._context.tracing.stop(path=str(trace_path))
+                print(f"[{self.name}] trace.zip 保存: {trace_path}")
+                print(f"[{self.name}] 再生: npx playwright show-trace {trace_path}")
+            except Exception as e:
+                print(f"[{self.name}] tracing 停止失敗: {e}")
         if hasattr(self, "_context"):
             self._context.close()
         if hasattr(self, "_playwright"):


### PR DESCRIPTION
## Summary

セゾン投信（saison-am）の特定口座年間取引報告書を tax-collect で自動収集する実装を追加。

## 実装フロー

```
www.saison-am.co.jp（top）
  → ログイン popup → app.saison-am.co.jp/?tab=0（OAuth経由）
  → マイページ link → /mypage
  → 報告書閲覧 div → 中継 popup（trade.saison-am → denshi-bato）
  → secdoc/newdenshibato（電子交付メニュー）
  → 「年間取引報告書」 link → 検索条件画面
  → select 設定（年間取引報告書 + 5年前から）→ 検索 button
  → 結果一覧 → subPdf link → popup B（PDF viewer）
  → popup URL を取得 → page.request.get() で PDF bytes 直接取得
```

## 主要な実装上のポイント

- **trade.saison-am 中継処理が ~5分**: popup 内で 60〜300 秒の middle ware 処理
- **5年範囲検索**: 過去年度報告書も取得可能、`target_year/12` と `target_year+1/01` の 2 パターン試行
- **PDF 取得方式**: Chromium 内蔵 PDF viewer は download イベント発火しないため、popup URL を取得して `request.get` で直接 fetch（paypay と同方式）

## BaseCollector 拡張

- `TRACE=true` env で Playwright trace.zip + network.har を `output/trace/<code>/<timestamp>/` に自動保存
- 新規サイト追加時のデバッグ効率化用

## Test plan

- [x] 単体動作確認: `python skills/tax-collect/sites/saison-am/collect.py --year 2025` → success
- [x] PDF→JSON 変換: `python skills/tax-collect/convert.py --year 2025 --codes saison-am` → success
- [ ] master マージ後、`python skills/tax-collect/run.py --year 2025 --sites saison-am` で run.py 経由動作確認

## 関連資料

- プラン: [plan/20260426_1212_issue36_saison-am-collect.md](../blob/feature/36_saison-am-collect/plan/20260426_1212_issue36_saison-am-collect.md)
- recorder 出力: `output/recorder/saison-am/20260426_120247/`（gitignore 対象）

Closes #36