### PR TITLE
feat: #43 ブラウザプロファイル backup/restore tool 追加

### DIFF
--- a/.workbench/alias_rules
+++ b/.workbench/alias_rules
@@ -13,3 +13,5 @@ test          $VENV_PYTHON -m pytest @args  # pytest 実行
 tax-collect   $VENV_PYTHON $PROJECT_ROOT/skills/tax-collect/run.py @args  # tax-collect 一括収集
 tax-convert   $VENV_PYTHON $PROJECT_ROOT/skills/tax-collect/convert.py @args  # PDF→JSON 直列変換（30秒delay）
 tax-recorder  $VENV_PYTHON $PROJECT_ROOT/skills/tax-collect/recorder.py @args  # 新規サイト追加用 操作記録
+browser-backup   $VENV_PYTHON $PROJECT_ROOT/tools/browser_profile.py backup @args   # ブラウザプロファイルバックアップ（data/browser/）
+browser-restore  $VENV_PYTHON $PROJECT_ROOT/tools/browser_profile.py restore @args  # ブラウザプロファイルリストア（~/.money-ops-browser/）

--- a/plan/20260427_0130_issue43_browser-profile-backup.md
+++ b/plan/20260427_0130_issue43_browser-profile-backup.md
@@ -73,13 +73,13 @@ browser-restore  $VENV_PYTHON $PROJECT_ROOT/tools/browser_profile.py restore @ar
 
 ## 実装タスク
 
-- [ ] `tools/browser_profile.py` 新設
+- [x] `tools/browser_profile.py` 新設
   - argparse で backup / restore サブコマンド
-  - backup: 全 or 単一 code を zip 化
+  - backup: 全 or 単一 code を zip 化（空ディレクトリも entry 記録）
   - restore: 最新 zip 自動選択 or --file 指定
   - 上書き確認プロンプト + `--yes` オプション
-- [ ] `.workbench/alias_rules` に browser-backup / browser-restore 追加
-- [ ] 動作確認: backup → 一旦 profile 削除 → restore で復元
+- [x] `.workbench/alias_rules` に browser-backup / browser-restore 追加
+- [x] 動作確認: backup → profile 削除 → restore で復元（diff -rq 完全一致確認済）
 
 ---
 

--- a/plan/20260427_0130_issue43_browser-profile-backup.md
+++ b/plan/20260427_0130_issue43_browser-profile-backup.md
@@ -1,0 +1,97 @@
+# #43 ブラウザプロファイル バックアップ・リストアツール
+
+## 対象 issue
+
+[#43](https://github.com/genba-neko/agent-skills-money-ops/issues/43)
+
+---
+
+## 背景
+
+- 各 code 別 Chromium persistent profile（`~/.money-ops-browser/<code>/`）は OneDrive 外
+- ディスク障害・誤削除・PC 移行時に喪失リスク
+- バックアップ手段必要
+
+---
+
+## 仕様
+
+### CLI
+
+```bash
+# 全 code バックアップ（デフォルト）
+python tools/browser_profile.py backup
+# → data/browser/all_2026-04-27.zip
+
+# 特定 code バックアップ
+python tools/browser_profile.py backup --code sbi
+# → data/browser/sbi_2026-04-27.zip
+
+# 全 code リストア（最新 all_*.zip 自動選択）
+python tools/browser_profile.py restore
+# → ~/.money-ops-browser/<各code>/ に展開
+
+# 特定 code リストア（最新 sbi_*.zip 自動選択）
+python tools/browser_profile.py restore --code sbi
+
+# ファイル明示指定
+python tools/browser_profile.py restore --file data/browser/sbi_2026-04-27.zip
+```
+
+### ファイル命名規則
+
+- 全 code: `all_YYYY-MM-DD.zip`
+- 特定 code: `{code}_YYYY-MM-DD.zip`
+- 同日複数回 backup の場合は上書き
+
+### バックアップ対象
+
+- `~/.money-ops-browser/<code>/` ディレクトリ全体
+- zip 内構造: `<code>/...` （展開時に `~/.money-ops-browser/` に解凍）
+
+### リストア挙動
+
+- 既存 profile を **上書き**（事前自動 backup なし）
+- 復元前に確認プロンプト（破壊的操作のため）
+- `--yes` で確認スキップ
+
+### file lock 対策
+
+- backup/restore 時に対象 code のブラウザ起動中だと失敗
+- 起動中検知（lock ファイル等）→ 警告 + 続行可否確認
+
+### alias
+
+`.workbench/alias_rules` に追加:
+
+```
+browser-backup   $VENV_PYTHON $PROJECT_ROOT/tools/browser_profile.py backup @args   # ブラウザプロファイルバックアップ
+browser-restore  $VENV_PYTHON $PROJECT_ROOT/tools/browser_profile.py restore @args  # ブラウザプロファイルリストア
+```
+
+---
+
+## 実装タスク
+
+- [ ] `tools/browser_profile.py` 新設
+  - argparse で backup / restore サブコマンド
+  - backup: 全 or 単一 code を zip 化
+  - restore: 最新 zip 自動選択 or --file 指定
+  - 上書き確認プロンプト + `--yes` オプション
+- [ ] `.workbench/alias_rules` に browser-backup / browser-restore 追加
+- [ ] 動作確認: backup → 一旦 profile 削除 → restore で復元
+
+---
+
+## 注意事項
+
+- profile ディレクトリの code 一覧取得: `~/.money-ops-browser/` の subdir を列挙
+- registry.json 参照は不要（profile が存在するもののみ対象）
+- zip ライブラリ: `zipfile` （標準ライブラリ）
+
+---
+
+## 参考
+
+- profile 保存先: `~/.money-ops-browser/<code>/`（base.py の `_browser_profile_dir`）
+- バックアップ保存先: `data/browser/`

--- a/tools/browser_profile.py
+++ b/tools/browser_profile.py
@@ -1,0 +1,229 @@
+"""ブラウザプロファイル バックアップ・リストアツール
+
+使い方:
+    # 全 code バックアップ
+    python tools/browser_profile.py backup
+    # → data/browser/all_YYYY-MM-DD.zip
+
+    # 特定 code バックアップ
+    python tools/browser_profile.py backup --code sbi
+    # → data/browser/sbi_YYYY-MM-DD.zip
+
+    # 全 code リストア（最新 all_*.zip 自動選択）
+    python tools/browser_profile.py restore
+
+    # 特定 code リストア（最新 {code}_*.zip 自動選択）
+    python tools/browser_profile.py restore --code sbi
+
+    # ファイル明示指定
+    python tools/browser_profile.py restore --file data/browser/sbi_2026-04-27.zip
+
+    # 確認スキップ
+    python tools/browser_profile.py restore --yes
+
+profile 保存先: ~/.money-ops-browser/<code>/
+backup 保存先: <project>/data/browser/
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+import zipfile
+from datetime import date
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_PROFILE_ROOT = Path.home() / ".money-ops-browser"
+_BACKUP_DIR = _PROJECT_ROOT / "data" / "browser"
+_LOCK_FILES = ("SingletonLock", "SingletonCookie", "SingletonSocket", "lockfile")
+_CODE_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def _list_codes() -> list[str]:
+    if not _PROFILE_ROOT.exists():
+        return []
+    return sorted(p.name for p in _PROFILE_ROOT.iterdir() if p.is_dir())
+
+
+def _is_browser_running(code: str) -> bool:
+    profile = _PROFILE_ROOT / code
+    return any((profile / lf).exists() for lf in _LOCK_FILES)
+
+
+def _confirm(msg: str, yes: bool) -> bool:
+    if yes:
+        return True
+    ans = input(f"{msg} [y/N]: ").strip().lower()
+    return ans in ("y", "yes")
+
+
+def _backup(codes: list[str], label: str, yes: bool) -> int:
+    """codes をすべて 1 つの zip にまとめて backup。"""
+    today = date.today().isoformat()
+    _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    zip_path = _BACKUP_DIR / f"{label}_{today}.zip"
+
+    running = [c for c in codes if _is_browser_running(c)]
+    if running:
+        print(f"[WARN] ブラウザ起動中の可能性: {', '.join(running)}")
+        if not _confirm("続行しますか?", yes):
+            print("[中止]")
+            return 1
+
+    if zip_path.exists():
+        print(f"[INFO] 既存ファイル上書き: {zip_path}")
+
+    print(f"[BACKUP] {len(codes)} code → {zip_path}")
+    total = 0
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for code in codes:
+            src = _PROFILE_ROOT / code
+            if not src.exists():
+                print(f"  [SKIP] {code}: profile なし")
+                continue
+            count = 0
+            dir_count = 0
+            # ディレクトリ entry (空ディレクトリ保持) → ファイル entry
+            for d in src.rglob("*"):
+                if not d.is_dir():
+                    continue
+                arc = (Path(code) / d.relative_to(src)).as_posix() + "/"
+                zf.writestr(zipfile.ZipInfo(arc), "")
+                dir_count += 1
+            for f in src.rglob("*"):
+                if not f.is_file():
+                    continue
+                arc = (Path(code) / f.relative_to(src)).as_posix()
+                try:
+                    zf.write(f, arcname=arc)
+                    count += 1
+                except (OSError, PermissionError) as e:
+                    print(f"  [WARN] skip {arc}: {e}")
+            print(f"  [OK] {code}: {count} files, {dir_count} dirs")
+            total += count
+
+    size_mb = zip_path.stat().st_size / (1024 * 1024)
+    print(f"[DONE] {total} files, {size_mb:.1f} MB → {zip_path}")
+    return 0
+
+
+def _find_latest(pattern: str) -> Path | None:
+    if not _BACKUP_DIR.exists():
+        return None
+    matches = sorted(_BACKUP_DIR.glob(pattern))
+    return matches[-1] if matches else None
+
+
+def _restore(zip_path: Path, code: str | None, yes: bool) -> int:
+    """zip_path を ~/.money-ops-browser/ 配下に展開。
+
+    code 指定時: zip 内の <code>/ のみ抽出。
+    code 省略時: zip 内すべて抽出。
+    既存 profile は上書き（事前削除）。
+    """
+    if not zip_path.exists():
+        print(f"[ERROR] ファイルなし: {zip_path}")
+        return 1
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        names = zf.namelist()
+        codes_in_zip = sorted({n.split("/", 1)[0] for n in names if "/" in n})
+
+    if code:
+        if code not in codes_in_zip:
+            print(f"[ERROR] zip 内に {code} なし。含まれる code: {codes_in_zip}")
+            return 1
+        target_codes = [code]
+    else:
+        target_codes = codes_in_zip
+
+    running = [c for c in target_codes if _is_browser_running(c)]
+    if running:
+        print(f"[WARN] ブラウザ起動中の可能性: {', '.join(running)}")
+        if not _confirm("続行すると profile が破壊されます。続行しますか?", yes):
+            print("[中止]")
+            return 1
+
+    existing = [c for c in target_codes if (_PROFILE_ROOT / c).exists()]
+    if existing:
+        print(f"[WARN] 既存 profile を上書きします: {', '.join(existing)}")
+        if not _confirm("続行しますか?", yes):
+            print("[中止]")
+            return 1
+
+    _PROFILE_ROOT.mkdir(parents=True, exist_ok=True)
+    print(f"[RESTORE] {zip_path} → {_PROFILE_ROOT}")
+
+    for c in target_codes:
+        dst = _PROFILE_ROOT / c
+        if dst.exists():
+            shutil.rmtree(dst)
+        print(f"  [OK] removed old profile: {c}")
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        if code:
+            members = [n for n in zf.namelist() if n.startswith(f"{code}/")]
+            zf.extractall(_PROFILE_ROOT, members=members)
+        else:
+            zf.extractall(_PROFILE_ROOT)
+
+    print(f"[DONE] restored: {', '.join(target_codes)}")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="ブラウザプロファイル バックアップ・リストアツール")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_b = sub.add_parser("backup", help="profile を zip 化")
+    p_b.add_argument("--code", help="特定 code のみ。省略時は全 code")
+    p_b.add_argument("--yes", action="store_true", help="確認スキップ")
+
+    p_r = sub.add_parser("restore", help="zip から profile を復元")
+    p_r.add_argument("--code", help="特定 code のみ。省略時は zip 内全 code")
+    p_r.add_argument("--file", help="復元元 zip ファイル明示指定")
+    p_r.add_argument("--yes", action="store_true", help="確認スキップ")
+
+    args = parser.parse_args()
+
+    if args.code and not _CODE_RE.match(args.code):
+        print(f"[ERROR] 不正な code: {args.code}")
+        sys.exit(1)
+
+    if args.cmd == "backup":
+        if args.code:
+            if not (_PROFILE_ROOT / args.code).exists():
+                print(f"[ERROR] profile なし: {_PROFILE_ROOT / args.code}")
+                sys.exit(1)
+            sys.exit(_backup([args.code], args.code, args.yes))
+        codes = _list_codes()
+        if not codes:
+            print(f"[ERROR] profile なし: {_PROFILE_ROOT}")
+            sys.exit(1)
+        sys.exit(_backup(codes, "all", args.yes))
+
+    if args.cmd == "restore":
+        if args.file:
+            zip_path = Path(args.file)
+            if not zip_path.is_absolute():
+                zip_path = _PROJECT_ROOT / zip_path
+        elif args.code:
+            zip_path = _find_latest(f"{args.code}_*.zip")
+            if not zip_path:
+                print(f"[ERROR] {args.code}_*.zip が見つかりません: {_BACKUP_DIR}")
+                sys.exit(1)
+            print(f"[INFO] 最新 zip: {zip_path.name}")
+        else:
+            zip_path = _find_latest("all_*.zip")
+            if not zip_path:
+                print(f"[ERROR] all_*.zip が見つかりません: {_BACKUP_DIR}")
+                sys.exit(1)
+            print(f"[INFO] 最新 zip: {zip_path.name}")
+        sys.exit(_restore(zip_path, args.code, args.yes))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `tools/browser_profile.py` 新設。`~/.money-ops-browser/<code>/` を `data/browser/` へ zip backup / restore
- backup: 全 code (`all_YYYY-MM-DD.zip`) or 単一 code (`{code}_YYYY-MM-DD.zip`)、空ディレクトリも entry 記録
- restore: 最新 zip 自動選択 / `--file` 明示指定、`--yes` で確認スキップ
- `.workbench/alias_rules` に `browser-backup` / `browser-restore` 追加

## Test plan
- [x] sbi 単独 backup → restore → diff 完全一致
- [x] 全件 backup → 全削除 → restore → diff 完全一致（空ディレクトリ含む）

関連: #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)