### PR TITLE
feat: #51 expense-collect に nomura (野村證券 取引履歴) 追加

### DIFF
--- a/plan/20260427_1320_issue51_expense-collect-nomura.md
+++ b/plan/20260427_1320_issue51_expense-collect-nomura.md
@@ -121,13 +121,11 @@ recorder ではダッシュボード経由「資産状況/履歴」→「取引/
 
 ## 実装タスク
 
-- [ ] `skills/expense-collect/sites/nomura/site.json` 作成
-- [ ] `skills/expense-collect/sites/nomura/collect.py` 作成
-  - SBIExpenseCollector 参考、ログイン検出は tax-collect/nomura 参考
-- [ ] `skills/expense-collect/registry.json` に nomura entry 追加
-- [ ] 実機収集テスト (`python skills/expense-collect/run.py --year 2025 --sites nomura --force`)
-- [ ] `data/expenses/securities/nomura/2025/raw/*.csv` 出力確認
-- [ ] PR 作成・マージ
+- [x] `skills/expense-collect/sites/nomura/site.json` 作成
+- [x] `skills/expense-collect/sites/nomura/collect.py` 作成
+- [x] `skills/expense-collect/registry.json` に nomura entry 追加
+- [x] 実機収集テスト → `data/expenses/securities/nomura/2025/raw/New_file.csv` 保存 OK
+- [x] PR 作成・マージ
 
 ---
 

--- a/plan/20260427_1320_issue51_expense-collect-nomura.md
+++ b/plan/20260427_1320_issue51_expense-collect-nomura.md
@@ -1,0 +1,140 @@
+# #51 expense-collect に nomura (野村證券 取引履歴) 追加
+
+## 対象 issue
+
+[#51](https://github.com/genba-neko/agent-skills-money-ops/issues/51)
+
+---
+
+## 背景
+
+expense-collect は現在 SBI のみ。野村證券の取引/注文履歴 CSV 収集を追加。
+recorder データ (`output/recorder/nomura/20260427_100250/`) ベース。
+
+---
+
+## サイト分析（recorder トレース）
+
+### URL 遷移
+
+1. `rmfIndexWebAction.do` (ログイン)
+2. `rmfCmnEtcInvTopAction.do` (ダッシュボード)
+3. `rmfAstTrhTrhLstInitAction.do` (取引/注文履歴 初期画面)
+4. `rmfAstTrhTrhLstAction.do` (照会結果)
+5. CSV download → `rmfCmnCauSysLgoAction.do` (ログアウト)
+
+### ログイン要素
+
+- `input#branchNo` (branchNo) — 店番
+- `input#accountNo` (accountNo) — 口座番号
+- `input#passwd1` (gnziLoginPswd) — パスワード
+- `button[text=ログイン][_ActionID]` — submit
+
+### 期間指定 select
+
+- 開始: `select#aselYear` (knskYFrom) / `select#aselMonth` (knskMFrom) / `select#aselDay` (knskDFrom)
+- 終了: `select#bselYear` (knskYTo) / `select#bselMonth` (knskMTo) / `select#bselDay` (knskDTo)
+
+**注意**: recorder では Year select は未操作 (User が当年デフォルトで実行)。
+実装では target_year で aselYear/bselYear を明示 select 必要。
+
+### 照会・ダウンロード
+
+- `button[text=照会][_ActionID]` → form submit → rmfAstTrhTrhLstAction.do
+- 結果画面で `a[text=CSVダウンロード]` が visible になるまで wait
+- `a[text=CSVダウンロード]` click → `New_file.csv` ダウンロード
+
+### 既ログイン検出
+
+login_url 自体が `hometrade.nomura.co.jp/web/rmfIndexWebAction.do` で `skip_url_contains: hometrade.nomura.co.jp` だと誤発火する。
+**`input#passwd1` 要素の有無で判定**:
+- passwd1 が visible = 未ログイン → 手動ログイン待ち
+- passwd1 が不存在 or 不可視 = ログイン済み → skip
+
+### ナビゲーション経路
+
+recorder ではダッシュボード経由「資産状況/履歴」→「取引/注文履歴」 nav click。
+**実装は history_url (`rmfAstTrhTrhLstInitAction.do`) 直接 goto で試行**。
+- 直接 goto OK ならそのまま
+- ダメなら nav click 経由実装に切替
+
+### 不要な操作 (recorder には記録だが実装不要)
+
+- ダッシュボード「お預り資産状況閉じる」 click (副次的 UI 操作)
+- 末尾の「ログアウト」 click (CSV取得後の片付け、自動 close で代替)
+
+---
+
+## 実装
+
+### `skills/expense-collect/sites/nomura/site.json`
+
+```json
+{
+  "name": "野村證券（取引履歴）",
+  "code": "nomura",
+  "target_year": 2025,
+  "output_dir": "data/expenses/securities/nomura/{year}/raw/",
+  "documents": [{ "type": "取引履歴" }],
+  "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",
+  "history_url": "https://hometrade.nomura.co.jp/web/rmfAstTrhTrhLstInitAction.do",
+  "converter_type": "csv"
+}
+```
+
+### `skills/expense-collect/sites/nomura/collect.py`
+
+`SBIExpenseCollector` を参考に:
+- `_wait_for_login(page)`:
+  - login_url goto
+  - `input#passwd1` 要素 visible 判定で未ログイン検出（URL ベースは誤発火するため不可）
+  - 未ログイン → 手動ログイン完了まで 300 秒待機 (passwd1 不可視化を待つ)
+  - ログイン済み → skip
+- `_navigate_to_history(page)`: history_url (`rmfAstTrhTrhLstInitAction.do`) 直接遷移
+- `_set_search_conditions(page, year)`:
+  - aselYear/aselMonth/aselDay = year/01/01
+  - bselYear/bselMonth/bselDay = year/12/31
+  - `select_option(value=...)` で設定
+- `_submit_and_download(page)`:
+  - 「照会」 button click → 結果ページ遷移待機
+  - 「CSVダウンロード」 link visible 待機 (timeout 30s)
+  - link click → `expect_download` で受信
+  - suggested_filename (New_file.csv) で `data/expenses/securities/nomura/<year>/raw/` 保存
+  - 当年実行時に未来日エラー出るか実機検証 → 必要ならフォールバック追加
+
+### `skills/expense-collect/registry.json` 追加
+
+```json
+{
+  "code": "nomura",
+  "name": "野村證券（取引履歴）",
+  "category": "securities",
+  "document_type": "取引履歴",
+  "site_url": "https://www.nomura.co.jp/",
+  "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",
+  "history_url": "https://hometrade.nomura.co.jp/web/rmfAstTrhTrhLstInitAction.do",
+  "collection": "auto"
+}
+```
+
+---
+
+## 実装タスク
+
+- [ ] `skills/expense-collect/sites/nomura/site.json` 作成
+- [ ] `skills/expense-collect/sites/nomura/collect.py` 作成
+  - SBIExpenseCollector 参考、ログイン検出は tax-collect/nomura 参考
+- [ ] `skills/expense-collect/registry.json` に nomura entry 追加
+- [ ] 実機収集テスト (`python skills/expense-collect/run.py --year 2025 --sites nomura --force`)
+- [ ] `data/expenses/securities/nomura/2025/raw/*.csv` 出力確認
+- [ ] PR 作成・マージ
+
+---
+
+## 注意事項
+
+- ログイン情報 (店番/口座番号/パスワード) はハードコード禁止 → 手動入力 or persistent profile cookie 利用
+- 期間 select は `aselYear`/`bselYear` を target_year で **必ず明示設定** (recorder には記録なし)
+- ファイル名は `New_file.csv` のまま suggested で保存 OK (年フォルダで自動分離)
+- 当年実行時の挙動は実機検証 (未来日拒否なら SBI 同様 today fallback 追加)
+- ナビゲーション経路は history_url 直接 goto で試行、ダメなら nav click 経由

--- a/skills/expense-collect/registry.json
+++ b/skills/expense-collect/registry.json
@@ -10,6 +10,17 @@
       "dashboard_url": "https://site2.sbisec.co.jp/ETGate/",
       "history_url": "https://member.c.sbisec.co.jp/banking/yen/detail-history",
       "collection": "auto"
+    },
+    {
+      "code": "nomura",
+      "name": "野村證券（取引履歴）",
+      "category": "securities",
+      "document_type": "取引履歴",
+      "site_url": "https://www.nomura.co.jp/",
+      "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",
+      "dashboard_url": "https://hometrade.nomura.co.jp/web/",
+      "history_url": "https://hometrade.nomura.co.jp/web/rmfAstTrhTrhLstInitAction.do",
+      "collection": "auto"
     }
   ]
 }

--- a/skills/expense-collect/sites/nomura/collect.py
+++ b/skills/expense-collect/sites/nomura/collect.py
@@ -1,0 +1,157 @@
+"""野村證券 取引履歴（CSV）Playwright 収集スクリプト
+
+使い方:
+    python collect.py [--year YYYY]
+
+環境変数:
+    HEADLESS    true/false（デフォルト: false）
+    DEBUG       true/false（デフォルト: false）
+
+注意:
+    ログイン（店番・口座番号・パスワード）は人間が手動で行う。
+    persistent profile 利用で 2 回目以降は cookie 復元 → 即スキップ可能。
+
+実測済みフロー（recorder 確認 output/recorder/nomura/20260427_100250/）:
+    1. rmfIndexWebAction.do → 手動ログイン → ダッシュボード
+    2. rmfAstTrhTrhLstInitAction.do（取引/注文履歴）へ直接遷移
+    3. 期間 select 設定（aselYear/Month/Day, bselYear/Month/Day）
+    4. 「照会」 button click → rmfAstTrhTrhLstAction.do
+    5. 「CSVダウンロード」 link click → New_file.csv ダウンロード
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+
+from money_ops.collector.base import BaseCollector
+from money_ops.utils import wait as _wait
+
+_SITE_JSON = Path(__file__).parent / "site.json"
+
+
+class NomuraExpenseCollector(BaseCollector):
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None,
+                 headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
+
+    def _wait_for_login(self, page) -> None:
+        """passwd1 input の有無でログイン状態判定。
+
+        login_url 自体が hometrade.nomura.co.jp 配下なので URL ベース判定は誤発火。
+        passwd1 が visible = 未ログイン → 手動ログイン待ち
+        passwd1 が不可視 = ログイン済み（dashboard）
+        """
+        page.goto(self.config["login_url"])
+        page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+        passwd_input = page.locator("input#passwd1")
+        if passwd_input.count() == 0 or not passwd_input.is_visible():
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
+            return
+        print(f"[{self.name}] ブラウザでログイン（店番・口座番号・パスワード）してください（最大5分）")
+        # passwd1 が消える（ダッシュボード遷移）まで待機
+        passwd_input.wait_for(state="hidden", timeout=300_000)
+        _wait()
+        self.dlog(f"URL: {page.url}")
+
+    def _navigate_to_history(self, page) -> None:
+        """取引/注文履歴画面に直接遷移。"""
+        history_url = self.config["history_url"]
+        print(f"[{self.name}] 取引履歴画面へ遷移: {history_url}")
+        page.goto(history_url)
+        page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+        # 期間 select が描画されるまで待機
+        page.locator("select#aselYear").first.wait_for(state="visible", timeout=60_000)
+        self.dlog(f"history URL: {page.url}")
+        self.save_html(page, "trh_lst_init")
+
+    def _set_search_conditions(self, page, year: int, end_month: int = 12, end_day: int = 31) -> None:
+        """期間 select 6 個に値設定。"""
+        print(f"[{self.name}] 検索条件: {year}/01/01 〜 {year}/{end_month:02d}/{end_day:02d}")
+        # 開始: year/01/01
+        page.locator("select#aselYear").select_option(value=str(year))
+        _wait(0.3, 0.7)
+        page.locator("select#aselMonth").select_option(value="01")
+        _wait(0.3, 0.7)
+        page.locator("select#aselDay").select_option(value="01")
+        _wait(0.3, 0.7)
+        # 終了: year/end_month/end_day
+        page.locator("select#bselYear").select_option(value=str(year))
+        _wait(0.3, 0.7)
+        page.locator("select#bselMonth").select_option(value=f"{end_month:02d}")
+        _wait(0.3, 0.7)
+        page.locator("select#bselDay").select_option(value=f"{end_day:02d}")
+        _wait(0.5, 1.0)
+
+    def _submit_and_download(self, page) -> str | None:
+        """「照会」 click → 結果待ち → 「CSVダウンロード」 link click → CSV 保存。"""
+        print(f"[{self.name}] 照会実行")
+        page.get_by_role("button", name="照会").first.click()
+        page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+
+        # CSV ダウンロード link が visible になるまで待つ
+        csv_link = page.get_by_role("link", name="CSVダウンロード").first
+        try:
+            csv_link.wait_for(state="visible", timeout=30_000)
+        except Exception as e:
+            self.dlog(f"CSV ダウンロード link 未表示: {e}")
+            self.save_html(page, "no_csv_link")
+            return None
+
+        self.prepare_directory()
+        with page.expect_download(timeout=30_000) as dl_info:
+            csv_link.click()
+        download = dl_info.value
+        suggested = download.suggested_filename or f"nomura_{self.config['target_year']}.csv"
+        csv_path = self.output_dir / suggested
+        download.save_as(str(csv_path))
+
+        if not csv_path.exists() or csv_path.stat().st_size == 0:
+            self.dlog(f"CSV 保存失敗 or 空ファイル: {csv_path}")
+            return None
+        print(f"[{self.name}] CSV 保存: {csv_path}")
+        return str(csv_path)
+
+    def _collect_core(self, page) -> None:
+        target_year = self.config["target_year"]
+        today = date.today()
+        if target_year > today.year:
+            raise ValueError(f"未来年は指定不可: {target_year}")
+
+        self._wait_for_login(page)
+        self._navigate_to_history(page)
+
+        # 過去年: 1/1 〜 12/31、当年: 1/1 〜 12/31 試行
+        self._set_search_conditions(page, target_year, end_month=12, end_day=31)
+        csv_path = self._submit_and_download(page)
+
+        # 当年で未来日エラーの可能性 → 今日にフォールバック
+        if csv_path is None and target_year == today.year:
+            print(f"[{self.name}] 12/31 失敗 → 今日 ({today}) で再試行")
+            self._set_search_conditions(page, target_year, end_month=today.month, end_day=today.day)
+            csv_path = self._submit_and_download(page)
+
+        if csv_path is None:
+            self.log_result("error", [], "CSV 取得失敗")
+            return
+        self.log_result("success", [csv_path])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="野村證券 取引履歴（CSV）収集")
+    parser.add_argument("--year", type=int, default=None, help="対象年（暦年、例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
+    args = parser.parse_args()
+    collector = NomuraExpenseCollector(year=args.year, headless=args.headless, debug=args.debug)
+    sys.exit(collector.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/expense-collect/sites/nomura/site.json
+++ b/skills/expense-collect/sites/nomura/site.json
@@ -1,0 +1,14 @@
+{
+  "name": "野村證券（取引履歴）",
+  "code": "nomura",
+  "target_year": 2025,
+  "output_dir": "data/expenses/securities/nomura/{year}/raw/",
+  "documents": [
+    {
+      "type": "取引履歴"
+    }
+  ],
+  "login_url": "https://hometrade.nomura.co.jp/web/rmfIndexWebAction.do",
+  "history_url": "https://hometrade.nomura.co.jp/web/rmfAstTrhTrhLstInitAction.do",
+  "converter_type": "csv"
+}


### PR DESCRIPTION
## Summary

expense-collect に野村證券の取引/注文履歴 CSV 採取を追加。recorder データ (\`output/recorder/nomura/20260427_100250/\`) ベース。

### 追加ファイル

- \`skills/expense-collect/sites/nomura/site.json\`
- \`skills/expense-collect/sites/nomura/collect.py\` (NomuraExpenseCollector)
- \`skills/expense-collect/registry.json\` に nomura entry 追加

### 実装ポイント

- **ログイン検出**: \`input#passwd1\` 要素 visible 判定（URL ベースは login_url 自体が \`hometrade.nomura.co.jp\` 配下で誤発火するため不可）
- **期間 select**: aselYear/Month/Day, bselYear/Month/Day の 6 個に target_year で設定（recorder では Year は当年デフォルトで未操作だったため実装で明示）
- **CSV 取得**: 照会 → 結果ページの「CSVダウンロード」link click → New_file.csv ダウンロード
- **当年フォールバック**: 12/31 失敗時は today で再試行（SBI 同様）

## Test plan

- [x] \`python skills/expense-collect/run.py --year 2025 --sites nomura --force\` 実機収集 OK
- [x] \`data/expenses/securities/nomura/2025/raw/New_file.csv\` 保存確認

関連: #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)