### PR TITLE
feat: #53 expense-collect に rakuten (楽天証券 入出金履歴) 追加

### DIFF
--- a/plan/20260427_1356_issue53_expense-collect-rakuten.md
+++ b/plan/20260427_1356_issue53_expense-collect-rakuten.md
@@ -84,12 +84,23 @@ recorder データ `output/recorder/rakuten/20260427_134019/` ベース。
 
 ## 実装タスク
 
-- [ ] `skills/expense-collect/sites/rakuten/site.json` 作成
-- [ ] `skills/expense-collect/sites/rakuten/collect.py` 作成
-- [ ] `skills/expense-collect/registry.json` に rakuten entry 追加
-- [ ] 実機収集テスト → `data/expenses/securities/rakuten/2025/raw/Withdrawallist_*.csv` 出力確認
-- [ ] CSV 行数確認（1515 行に近い数値か）
-- [ ] PR 作成・マージ
+- [x] `skills/expense-collect/sites/rakuten/site.json` 作成
+- [x] `skills/expense-collect/sites/rakuten/collect.py` 作成
+- [x] `skills/expense-collect/registry.json` に rakuten entry 追加
+- [x] 実機収集テスト → `data/expenses/securities/rakuten/2025/raw/Withdrawallist_20260427.csv` (1515 行) 出力確認
+- [x] PR 作成・マージ
+
+## 実装中の修正履歴
+
+1. login_url を `MhLogin.do?login_type=1` → `https://www.rakuten-sec.co.jp/` (top) に変更
+   （直接 MhLogin.do は session 切れで session_error.html に redirect されるため）
+2. ログイン状態判定 `_is_dashboard` を URL path ベースに変更
+   （query の `login_type=1` を誤検出して dashboard 判定 False になる問題）
+3. 履歴ページ遷移を nav click 経由に変更
+   （直接 goto では BV_SessionID 不足で form 表示されない）
+4. form selector を `form#AssMoneyTransLstForm` (id) → `form[name='AssMoneyTransLstForm']` に変更
+   （HTML 実態は name 属性のみ、id なし。recorder の sel 表記 `form#...` は誤読しやすかった）
+5. login タイムアウト 5分 → 10分に延長
 
 ---
 

--- a/plan/20260427_1356_issue53_expense-collect-rakuten.md
+++ b/plan/20260427_1356_issue53_expense-collect-rakuten.md
@@ -1,0 +1,101 @@
+# #53 expense-collect に rakuten (楽天証券 入出金履歴) 追加
+
+## 対象 issue
+
+[#53](https://github.com/genba-neko/agent-skills-money-ops/issues/53)
+
+---
+
+## 背景
+
+配当金入金の集計用に楽天証券の入出金履歴 CSV 採取を追加。
+recorder データ `output/recorder/rakuten/20260427_134019/` ベース。
+
+---
+
+## サイト分析
+
+### URL
+
+- ログイン: `https://member.rakuten-sec.co.jp/app/MhLogin.do?login_type=1` （tax-collect/rakuten と統一）
+- 入出金履歴: `https://member.rakuten-sec.co.jp/app/ass_money_trans_lst.do?eventType=init&gmn=S&smn=03&lmn=03&fmn=01`
+  - 注意: BV_SessionID はセッションごとに変わる → query 部分のみ使用
+- CSV download: 入出金履歴ページ内 `img.roll` (CSV エクスポート画像 link)
+
+### CSV 仕様
+
+- ファイル名: `Withdrawallist_<YYYYMMDD>.csv`
+- 1 click で **全期間 1515 行**（ヘッダ + 全件）取得済確認
+- ページネーション (12 ページ) は画面表示用、CSV エクスポートには反映されない
+
+### ログイン
+
+- tax-collect/rakuten/collect.py の `_wait_for_login` 流用
+  - login_url を tax-collect 側と同じにすることで 1 ステップ短縮（`www.rakuten-sec.co.jp/ITS/...` 経由不要）
+- URL ベース判定: `member.rakuten-sec.co.jp/app/` 配下到達 + `Login` を含まない → skip
+- 絵文字認証・パスキーは手動（300秒待機）
+
+---
+
+## 実装
+
+### `skills/expense-collect/sites/rakuten/site.json`
+
+```json
+{
+  "name": "楽天証券（入出金履歴）",
+  "code": "rakuten",
+  "target_year": 2025,
+  "output_dir": "data/expenses/securities/rakuten/{year}/raw/",
+  "documents": [{ "type": "入出金履歴" }],
+  "login_url": "https://member.rakuten-sec.co.jp/app/MhLogin.do?login_type=1",
+  "history_url": "https://member.rakuten-sec.co.jp/app/ass_money_trans_lst.do?eventType=init&gmn=S&smn=03&lmn=03&fmn=01",
+  "converter_type": "csv"
+}
+```
+
+### `skills/expense-collect/sites/rakuten/collect.py`
+
+`SBIExpenseCollector` 構造踏襲、ログイン部分は tax-collect/rakuten 参考:
+- `_wait_for_login(page)`: login_url goto → URL に member.rakuten-sec.co.jp/app/ 含み Login 含まなければ skip、なければ手動ログイン待ち（300秒）
+- `_navigate_to_history(page)`: history_url 直接 goto
+- `_submit_and_download(page)`: CSV エクスポート link click → expect_download → suggested_filename で保存
+  - **selector 戦略**: 入出金履歴ページ内に img.roll が複数ある可能性
+    - 第一候補: `form#AssMoneyTransLstForm img.roll`（form 内に限定）
+    - フォールバック: `tbody > tr > td > div.mbody > a > img.roll` の `.first`
+    - 実機検証で確定
+
+### `skills/expense-collect/registry.json` 追加
+
+```json
+{
+  "code": "rakuten",
+  "name": "楽天証券（入出金履歴）",
+  "category": "securities",
+  "document_type": "入出金履歴",
+  "site_url": "https://www.rakuten-sec.co.jp/",
+  "login_url": "https://member.rakuten-sec.co.jp/app/MhLogin.do?login_type=1",
+  "history_url": "https://member.rakuten-sec.co.jp/app/ass_money_trans_lst.do?eventType=init&gmn=S&smn=03&lmn=03&fmn=01",
+  "collection": "auto"
+}
+```
+
+---
+
+## 実装タスク
+
+- [ ] `skills/expense-collect/sites/rakuten/site.json` 作成
+- [ ] `skills/expense-collect/sites/rakuten/collect.py` 作成
+- [ ] `skills/expense-collect/registry.json` に rakuten entry 追加
+- [ ] 実機収集テスト → `data/expenses/securities/rakuten/2025/raw/Withdrawallist_*.csv` 出力確認
+- [ ] CSV 行数確認（1515 行に近い数値か）
+- [ ] PR 作成・マージ
+
+---
+
+## 注意事項
+
+- target_year は CSV エクスポートに反映されない（全期間取得）→ 年フォルダ分離だが内容は全期間同じ
+  - 後段の集計処理で year フィルタ必要
+  - site.json target_year は管理用 (output_dir 用)
+- 配当金集計は CSV 内の摘要行で抽出（後段処理、本タスクの責務外）

--- a/skills/expense-collect/registry.json
+++ b/skills/expense-collect/registry.json
@@ -21,6 +21,17 @@
       "dashboard_url": "https://hometrade.nomura.co.jp/web/",
       "history_url": "https://hometrade.nomura.co.jp/web/rmfAstTrhTrhLstInitAction.do",
       "collection": "auto"
+    },
+    {
+      "code": "rakuten",
+      "name": "楽天証券（入出金履歴）",
+      "category": "securities",
+      "document_type": "入出金履歴",
+      "site_url": "https://www.rakuten-sec.co.jp/",
+      "login_url": "https://www.rakuten-sec.co.jp/",
+      "dashboard_url": "https://member.rakuten-sec.co.jp/app/",
+      "history_url": "https://member.rakuten-sec.co.jp/app/ass_money_trans_lst.do?eventType=init&gmn=S&smn=03&lmn=03&fmn=01",
+      "collection": "auto"
     }
   ]
 }

--- a/skills/expense-collect/sites/rakuten/collect.py
+++ b/skills/expense-collect/sites/rakuten/collect.py
@@ -1,0 +1,125 @@
+"""楽天証券 入出金履歴（CSV）Playwright 収集スクリプト
+
+使い方:
+    python collect.py [--year YYYY]
+
+環境変数:
+    HEADLESS    true/false（デフォルト: false）
+    DEBUG       true/false（デフォルト: false）
+
+注意:
+    ログイン（ID・パスワード・絵文字認証・二段階認証）は人間が手動で行う。
+    persistent profile 利用で 2 回目以降は cookie 復元 → 即スキップ可能。
+
+実測済みフロー（recorder 確認 output/recorder/rakuten/20260427_134019/）:
+    1. MhLogin.do → 手動ログイン（絵文字認証含む） → ダッシュボード
+    2. ass_money_trans_lst.do（入出金履歴）に直接遷移
+    3. CSV エクスポート link click → Withdrawallist_<YYYYMMDD>.csv ダウンロード
+       （1 click で全期間 1515 行 全件取得確認済、ページネーション無視可）
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from money_ops.collector.base import BaseCollector
+from money_ops.utils import wait as _wait
+
+_SITE_JSON = Path(__file__).parent / "site.json"
+
+
+class RakutenExpenseCollector(BaseCollector):
+    def __init__(self, site_json_path: str | Path = _SITE_JSON, year: int | None = None,
+                 headless: bool | None = None, debug: bool | None = None):
+        super().__init__(site_json_path, year, headless=headless, debug=debug)
+
+    def _wait_for_login(self, page) -> None:
+        """tax-collect/rakuten と同方針: member.rakuten-sec.co.jp/app/ + Login 含まなければ skip。"""
+        def _is_dashboard(url: str) -> bool:
+            # path 部分のみで判定（query の login_type=1 等を誤検出しないため）
+            # /app/Login.do, /app/MhLogin.do, /app/sotp_login.do を除外、
+            # /app/home.do, /app/com_page_template.do 等を許可
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+            if "rakuten-sec.co.jp" not in parsed.netloc:
+                return False
+            path = parsed.path or ""
+            return (
+                path.startswith("/app/")
+                and "login" not in path.lower()
+            )
+
+        page.goto(self.config["login_url"])
+        page.wait_for_load_state("domcontentloaded")
+        _wait(1.5, 2.5)
+        if _is_dashboard(page.url):
+            print(f"[{self.name}] ログイン済みを検出 → スキップ")
+            self.dlog(f"URL: {page.url}")
+            return
+        print(f"[{self.name}] ブラウザでログインしてください（絵文字認証・二段階認証含む）（最大10分）")
+        page.wait_for_url(lambda url: _is_dashboard(url), timeout=600_000)
+        _wait()
+        self.dlog(f"URL: {page.url}")
+
+    def _navigate_to_history(self, page) -> None:
+        """マイメニュー → 入出金履歴 経由で遷移（BV_SessionID 自動付与のため直接 goto 不可）。"""
+        print(f"[{self.name}] マイメニュー → 入出金履歴")
+        page.get_by_role("button", name=re.compile("マイメニュー")).click()
+        _wait()
+        page.get_by_role("link", name="入出金履歴").click()
+        page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+        page.locator("form[name='AssMoneyTransLstForm']").first.wait_for(state="visible", timeout=60_000)
+        self.dlog(f"history URL: {page.url}")
+        self.save_html(page, "money_trans_lst")
+
+    def _submit_and_download(self, page) -> str | None:
+        """CSV エクスポート img click → CSV 保存。"""
+        print(f"[{self.name}] CSV エクスポート")
+        csv_link = page.locator("form[name='AssMoneyTransLstForm'] img.roll").first
+        try:
+            csv_link.wait_for(state="visible", timeout=30_000)
+        except Exception as e:
+            self.dlog(f"CSV エクスポート link 未表示: {e}")
+            self.save_html(page, "no_csv_link")
+            return None
+
+        self.prepare_directory()
+        with page.expect_download(timeout=30_000) as dl_info:
+            csv_link.click()
+        download = dl_info.value
+        suggested = download.suggested_filename or f"rakuten_{self.config['target_year']}.csv"
+        csv_path = self.output_dir / suggested
+        download.save_as(str(csv_path))
+
+        if not csv_path.exists() or csv_path.stat().st_size == 0:
+            self.dlog(f"CSV 保存失敗 or 空ファイル: {csv_path}")
+            return None
+        print(f"[{self.name}] CSV 保存: {csv_path}")
+        return str(csv_path)
+
+    def _collect_core(self, page) -> None:
+        self._wait_for_login(page)
+        self._navigate_to_history(page)
+        csv_path = self._submit_and_download(page)
+        if csv_path is None:
+            self.log_result("error", [], "CSV 取得失敗")
+            return
+        self.log_result("success", [csv_path])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="楽天証券 入出金履歴（CSV）収集")
+    parser.add_argument("--year", type=int, default=None, help="対象年（暦年、例: 2025）")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=None)
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction, default=None)
+    args = parser.parse_args()
+    collector = RakutenExpenseCollector(year=args.year, headless=args.headless, debug=args.debug)
+    sys.exit(collector.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/expense-collect/sites/rakuten/site.json
+++ b/skills/expense-collect/sites/rakuten/site.json
@@ -1,0 +1,14 @@
+{
+  "name": "楽天証券（入出金履歴）",
+  "code": "rakuten",
+  "target_year": 2025,
+  "output_dir": "data/expenses/securities/rakuten/{year}/raw/",
+  "documents": [
+    {
+      "type": "入出金履歴"
+    }
+  ],
+  "login_url": "https://www.rakuten-sec.co.jp/",
+  "history_url": "https://member.rakuten-sec.co.jp/app/ass_money_trans_lst.do?eventType=init&gmn=S&smn=03&lmn=03&fmn=01",
+  "converter_type": "csv"
+}


### PR DESCRIPTION
## Summary

楽天証券の入出金履歴 CSV 採取を expense-collect に追加。配当金入金集計が目的。
recorder データ (\`output/recorder/rakuten/20260427_134019/\`) ベース。

### 採取仕様

- 1 click で **全期間 1515 行（全件）取得**
- ファイル名: \`Withdrawallist_<YYYYMMDD>.csv\`
- ページネーションは画面表示のみで CSV エクスポートには反映されない → 巡回不要

### 実装の試行錯誤

実機検証で複数の問題を解消:
1. 直接 \`MhLogin.do\` は session 切れで \`session_error.html\` redirect → top page 経由に変更
2. URL path で login 判定（query の \`login_type=1\` 誤検出回避）
3. 履歴は直接 goto 不可（BV_SessionID 不足）→ マイメニュー → 入出金履歴 nav click 経由
4. form selector は \`form[name='AssMoneyTransLstForm']\` (id 属性なし、name 属性のみ)
5. login timeout 10分（絵文字認証含むため）

## Test plan

- [x] 実機: \`python skills/expense-collect/run.py --year 2025 --sites rakuten --force\` 成功
- [x] 出力: \`data/expenses/securities/rakuten/2025/raw/Withdrawallist_20260427.csv\` (1515 行)

関連: #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)