### PR TITLE
feat: #56 rakuten collector に配当金履歴 CSV 採取追加

### DIFF
--- a/plan/20260427_1530_issue56_rakuten-dividend.md
+++ b/plan/20260427_1530_issue56_rakuten-dividend.md
@@ -85,16 +85,17 @@ def _collect_core(self, page) -> None:
 
 ## 実装タスク
 
-- [ ] `skills/expense-collect/sites/rakuten/collect.py` 拡張
-  - `_navigate_to_dividend` 追加
+- [x] `skills/expense-collect/sites/rakuten/collect.py` 拡張
+  - `_navigate_to_dividend` 追加 (megaMenu 内に limit で strict mode 回避)
   - `_set_dividend_period` 追加 (期間 select 6個)
-  - `_submit_and_download_dividend` 追加 (CSV link selector は HAR/recorder 再分析で確定)
+  - `_submit_and_download_dividend` 追加 (`a[onclick*='csvOutput']` selector)
   - `_collect_core` で 2段階採取に変更
-- [ ] 実機テスト
-  - `python skills/expense-collect/run.py --year 2025 --sites rakuten --force`
-  - 両 CSV 保存確認: `Withdrawallist_*.csv` + `dividendlist_*.csv`
-- [ ] 配当金 CSV の中身サンプリング確認 (列構成、列名、件数)
-- [ ] PR 作成・マージ
+- [x] 実機テスト → 両 CSV 出力確認:
+  - `Withdrawallist_20260427.csv` 1515 行 (入出金)
+  - `dividendlist_20260427.csv` 59 行 (配当金)
+- [x] 配当金 CSV の中身確認:
+  列: 入金日 / 商品 / 口座 / 銘柄コード / 銘柄 / 受取通貨 / 単価 / 数量 / 配当・分配金合計(税引前) / 税額合計 / 受取金額
+- [x] PR 作成
 
 ---
 

--- a/plan/20260427_1530_issue56_rakuten-dividend.md
+++ b/plan/20260427_1530_issue56_rakuten-dividend.md
@@ -1,0 +1,114 @@
+# #56 rakuten collector に配当金履歴 CSV 採取追加
+
+## 対象 issue
+
+[#56](https://github.com/genba-neko/agent-skills-money-ops/issues/56)
+
+---
+
+## 背景
+
+PR #54 で採取した入出金履歴 CSV (Withdrawallist) には配当金が含まれず（楽天銀行 ↔ 証券口座間の資金移動と株購入用入金のみ）、配当金集計のため別画面採取が必要。
+
+recorder データ `output/recorder/rakuten/20260427_152252/` で配当・分配金画面のフロー確認済。
+
+---
+
+## サイト分析（recorder 確認）
+
+### URL
+
+- 配当・分配金画面: `https://member.rakuten-sec.co.jp/app/ass_dividend_history.do?eventType=init&gmn=S&smn=06&lmn=01&fmn=01`
+- CSV download: 同 URL の `?eventType=csv`
+- ファイル名: `dividendlist_<YYYYMMDD>.csv`
+
+### Nav 経路
+
+1. ログイン → home.do (PR #54 で実装済の流れ流用)
+2. 「口座管理・入出金など」 button
+3. 「配当・分配金」 link
+4. ass_dividend_history.do 到達
+
+### 期間 select
+
+- 開始: `select#yearFrom`, `select#monthFrom`, `select#dayFrom`
+- 終了: `select#yearTo`, `select#monthTo`, `select#dayTo`
+- target_year で 1/1〜12/31 設定
+
+### CSV エクスポート
+
+recorder の click 操作不明（DL イベントのみ取得）。
+URL パターンから推測: `img.roll` 等の link click → `?eventType=csv` への navigation で download。
+入出金履歴と同じ仕組みと推測。
+
+---
+
+## 実装方針
+
+`RakutenExpenseCollector._collect_core` を拡張:
+
+```python
+def _collect_core(self, page) -> None:
+    self._wait_for_login(page)
+    paths = []
+
+    # 1. 入出金履歴 (既存)
+    self._navigate_to_history(page)  # マイメニュー → 入出金履歴
+    p1 = self._submit_and_download(page)
+    if p1: paths.append(p1)
+
+    # 2. 配当金履歴 (追加)
+    self._navigate_to_dividend(page)  # マイメニュー → 配当・分配金
+    self._set_dividend_period(page)
+    p2 = self._submit_and_download_dividend(page)
+    if p2: paths.append(p2)
+
+    if not paths:
+        self.log_result("error", [], "両 CSV 取得失敗")
+    else:
+        self.log_result("success", paths)
+```
+
+### 新メソッド
+
+- `_navigate_to_dividend(page)`: マイメニュー → 「配当・分配金」 link click
+- `_set_dividend_period(page)`: yearFrom/monthFrom/dayFrom + yearTo/monthTo/dayTo 6 select 設定
+- `_submit_and_download_dividend(page)`: CSV エクスポート link click → `dividendlist_*.csv` 保存
+
+### 出力先
+
+`data/expenses/securities/rakuten/<year>/raw/` 配下に:
+- `Withdrawallist_<date>.csv` (入出金、既存)
+- `dividendlist_<date>.csv` (配当金、追加)
+
+---
+
+## 実装タスク
+
+- [ ] `skills/expense-collect/sites/rakuten/collect.py` 拡張
+  - `_navigate_to_dividend` 追加
+  - `_set_dividend_period` 追加 (期間 select 6個)
+  - `_submit_and_download_dividend` 追加 (CSV link selector は HAR/recorder 再分析で確定)
+  - `_collect_core` で 2段階採取に変更
+- [ ] 実機テスト
+  - `python skills/expense-collect/run.py --year 2025 --sites rakuten --force`
+  - 両 CSV 保存確認: `Withdrawallist_*.csv` + `dividendlist_*.csv`
+- [ ] 配当金 CSV の中身サンプリング確認 (列構成、列名、件数)
+- [ ] PR 作成・マージ
+
+---
+
+## 注意事項
+
+- 入出金履歴側 (PR #54 実装) は変更せず、配当金処理を後続で追加
+- マイメニューを 2 回開くため _wait 適切に挟む
+- 配当金画面 form の selector / CSV link の selector は HAR で確認 (recorder の click 記録なし)
+- ログイン状態は 1 回で 2 画面分カバー (collector 1 セッション)
+
+---
+
+## 関連
+
+- recorder: `output/recorder/rakuten/20260427_152252/`
+- 既存実装: `skills/expense-collect/sites/rakuten/collect.py` (PR #54 で導入)
+- 後続: #55 共通フォーマット正規化（配当金 CSV あり前提で進めやすくなる）

--- a/skills/expense-collect/sites/rakuten/collect.py
+++ b/skills/expense-collect/sites/rakuten/collect.py
@@ -130,17 +130,18 @@ class RakutenExpenseCollector(BaseCollector):
         _wait(0.5, 1.0)
 
     def _submit_and_download_dividend(self, page) -> str | None:
-        """配当金画面の CSV エクスポート: <a onclick='csvOutput()'> click → ?eventType=csv navigation。"""
-        print(f"[{self.name}] 配当金 CSV エクスポート")
-        # 照会 button が必要なら先に click（form 名で limit）
-        try:
-            inquiry = page.locator("form[name='AssDividendHistoryForm'] input[type='submit'], form[name='AssDividendHistoryForm'] button[type='submit']").first
-            if inquiry.count() > 0:
-                inquiry.click()
-                page.wait_for_load_state("domcontentloaded")
-                _wait(2.0, 3.0)
-        except Exception:
-            pass
+        """配当金画面の CSV エクスポート。
+
+        フロー:
+            1. 「表示」 button (input[type=image] onclick='clickSearch()') click
+               → eventType=search に設定 + form submit → 期間絞り込み結果表示
+            2. CSV エクスポート link (a[onclick='csvOutput()']) click → DL
+        """
+        print(f"[{self.name}] 表示 button → CSV エクスポート")
+        # 「表示」 button click（期間絞り込みを反映するため必須）
+        page.locator("form[name='AssDividendHistoryForm'] input[type='image'][onclick*='clickSearch']").first.click()
+        page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
 
         csv_link = page.locator("a[onclick*='csvOutput']").first
         try:

--- a/skills/expense-collect/sites/rakuten/collect.py
+++ b/skills/expense-collect/sites/rakuten/collect.py
@@ -186,6 +186,8 @@ class RakutenExpenseCollector(BaseCollector):
         if not paths:
             self.log_result("error", [], "両 CSV 取得失敗")
             return
+        if len(paths) < 2:
+            print(f"[{self.name}] [WARN] 部分取得 ({len(paths)}/2): {paths}")
         self.log_result("success", paths)
 
 

--- a/skills/expense-collect/sites/rakuten/collect.py
+++ b/skills/expense-collect/sites/rakuten/collect.py
@@ -101,14 +101,91 @@ class RakutenExpenseCollector(BaseCollector):
         print(f"[{self.name}] CSV 保存: {csv_path}")
         return str(csv_path)
 
+    def _navigate_to_dividend(self, page) -> None:
+        """マイメニュー → 配当・分配金。"""
+        print(f"[{self.name}] マイメニュー → 配当・分配金")
+        page.get_by_role("button", name=re.compile("マイメニュー")).click()
+        _wait()
+        page.locator("#megaMenu").get_by_role("link", name="配当・分配金").click()
+        page.wait_for_load_state("domcontentloaded")
+        _wait(2.0, 3.0)
+        page.locator("form[name='AssDividendHistoryForm']").first.wait_for(state="visible", timeout=60_000)
+        self.dlog(f"dividend URL: {page.url}")
+        self.save_html(page, "dividend_history")
+
+    def _set_dividend_period(self, page, year: int) -> None:
+        """期間 select 設定: year/01/01 〜 year/12/31。"""
+        print(f"[{self.name}] 期間設定: {year}/01/01 〜 {year}/12/31")
+        page.locator("select#yearFrom").select_option(value=str(year))
+        _wait(0.3, 0.7)
+        page.locator("select#monthFrom").select_option(value="01")
+        _wait(0.3, 0.7)
+        page.locator("select#dayFrom").select_option(value="01")
+        _wait(0.3, 0.7)
+        page.locator("select#yearTo").select_option(value=str(year))
+        _wait(0.3, 0.7)
+        page.locator("select#monthTo").select_option(value="12")
+        _wait(0.3, 0.7)
+        page.locator("select#dayTo").select_option(value="31")
+        _wait(0.5, 1.0)
+
+    def _submit_and_download_dividend(self, page) -> str | None:
+        """配当金画面の CSV エクスポート: <a onclick='csvOutput()'> click → ?eventType=csv navigation。"""
+        print(f"[{self.name}] 配当金 CSV エクスポート")
+        # 照会 button が必要なら先に click（form 名で limit）
+        try:
+            inquiry = page.locator("form[name='AssDividendHistoryForm'] input[type='submit'], form[name='AssDividendHistoryForm'] button[type='submit']").first
+            if inquiry.count() > 0:
+                inquiry.click()
+                page.wait_for_load_state("domcontentloaded")
+                _wait(2.0, 3.0)
+        except Exception:
+            pass
+
+        csv_link = page.locator("a[onclick*='csvOutput']").first
+        try:
+            csv_link.wait_for(state="visible", timeout=30_000)
+        except Exception as e:
+            self.dlog(f"配当金 CSV link 未表示: {e}")
+            self.save_html(page, "no_dividend_csv_link")
+            return None
+
+        self.prepare_directory()
+        with page.expect_download(timeout=30_000) as dl_info:
+            csv_link.click()
+        download = dl_info.value
+        suggested = download.suggested_filename or f"dividendlist_{self.config['target_year']}.csv"
+        csv_path = self.output_dir / suggested
+        download.save_as(str(csv_path))
+
+        if not csv_path.exists() or csv_path.stat().st_size == 0:
+            self.dlog(f"配当金 CSV 保存失敗 or 空ファイル: {csv_path}")
+            return None
+        print(f"[{self.name}] 配当金 CSV 保存: {csv_path}")
+        return str(csv_path)
+
     def _collect_core(self, page) -> None:
         self._wait_for_login(page)
+        paths = []
+
+        # 1. 入出金履歴
         self._navigate_to_history(page)
-        csv_path = self._submit_and_download(page)
-        if csv_path is None:
-            self.log_result("error", [], "CSV 取得失敗")
+        p1 = self._submit_and_download(page)
+        if p1:
+            paths.append(p1)
+
+        # 2. 配当金履歴
+        target_year = self.config["target_year"]
+        self._navigate_to_dividend(page)
+        self._set_dividend_period(page, target_year)
+        p2 = self._submit_and_download_dividend(page)
+        if p2:
+            paths.append(p2)
+
+        if not paths:
+            self.log_result("error", [], "両 CSV 取得失敗")
             return
-        self.log_result("success", [csv_path])
+        self.log_result("success", paths)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

PR #54 で採取した楽天証券の入出金履歴 (Withdrawallist) には配当金が含まれない（楽天銀行 ↔ 証券口座間の資金移動と株購入用入金のみ）ため、配当・分配金画面 (\`ass_dividend_history.do\`) からの追加採取を実装。

### 変更内容

\`RakutenExpenseCollector._collect_core\` を拡張、入出金 + 配当金 両方を同一セッションで取得:

- \`_navigate_to_dividend\`: マイメニュー → 配当・分配金（megaMenu 内 limit で strict mode 回避）
- \`_set_dividend_period\`: yearFrom/monthFrom/dayFrom + yearTo/monthTo/dayTo
- \`_submit_and_download_dividend\`: 「表示」 button (\`input[type=image][onclick*='clickSearch']\`) click → CSV link (\`a[onclick*='csvOutput']\`) click → DL
  - **期間絞り込み反映には「表示」 button click 必須**（修正前は全期間データが返ってた）

### 出力

\`data/expenses/securities/rakuten/<year>/raw/\` 配下に:
- \`Withdrawallist_<date>.csv\` (入出金、PR #54)
- \`dividendlist_<date>.csv\` (配当金、本 PR)

### 配当金 CSV 列

入金日 / 商品 / 口座 / 銘柄コード / 銘柄 / 受取通貨 / 単価 / 数量 / 配当・分配金合計（税引前） / 税額合計 / 受取金額

## Test plan

- [x] 実機: \`python skills/expense-collect/run.py --year 2025 --sites rakuten --force\`
- [x] 両 CSV 出力確認:
  - \`Withdrawallist_20260427.csv\` 1515 行
  - \`dividendlist_20260427.csv\` 92 行（2025/01/09〜2025/12/30 全件 2025 年）

関連: #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)